### PR TITLE
fix(setup): keys before variants, auto-.env, per-key explainer, Playwright-first

### DIFF
--- a/bin/adforge.js
+++ b/bin/adforge.js
@@ -92,24 +92,39 @@ function cmdInit(targetDir) {
 }
 
 function cmdDoctor() {
-  const checks = [
+  const required = [
     { name: "node", cmd: "node --version", min: "18" },
     { name: "python3", cmd: "python3 --version" },
     { name: "pip", cmd: "pip3 --version" },
     { name: "ffmpeg (for Remotion)", cmd: "ffmpeg -version" },
   ];
+  const optional = [
+    {
+      name: "playwright (brand extraction)",
+      cmd: "python3 -c \"import playwright\"",
+      hint: "pip install playwright && playwright install chromium",
+    },
+  ];
   log("adforge doctor\n");
   let ok = true;
-  for (const c of checks) {
+  for (const c of required) {
     try {
       const out = execSync(c.cmd, { stdio: ["ignore", "pipe", "ignore"] }).toString().split("\n")[0];
-      log(`  \u2713 ${c.name.padEnd(24)} ${out}`);
+      log(`  \u2713 ${c.name.padEnd(32)} ${out}`);
     } catch (e) {
       ok = false;
-      log(`  \u2717 ${c.name.padEnd(24)} not found`);
+      log(`  \u2717 ${c.name.padEnd(32)} not found`);
     }
   }
-  log(ok ? "\nall good." : "\nsome deps missing — install them and retry.");
+  for (const c of optional) {
+    try {
+      execSync(c.cmd, { stdio: ["ignore", "ignore", "ignore"] });
+      log(`  \u2713 ${c.name.padEnd(32)} installed`);
+    } catch (e) {
+      log(`  \u25cb ${c.name.padEnd(32)} not installed (optional) — ${c.hint}`);
+    }
+  }
+  log(ok ? "\nall required deps present." : "\nsome required deps missing — install them and retry.");
   process.exit(ok ? 0 : 1);
 }
 

--- a/templates/.claude/skills/adforge/SKILL.md
+++ b/templates/.claude/skills/adforge/SKILL.md
@@ -10,10 +10,11 @@ You are the entry point for the adforge pipeline. Your job is to read the projec
 ## On invocation
 
 1. Read `adforge.config.json` and `brand.json` to confirm this is an adforge project. If not: politely tell the user to run `npx adforge init <dir>` first.
-2. If `.adforge/state.json` exists, summarise what's deployed:
+2. If `.env` is missing (and `.env.example` exists), this is a first-time setup. Do NOT show the menu — route straight into the `setup` skill. Onboarding (API keys first) has to happen before anything else renders, or you will generate a campaign's worth of creatives on fallback hero modes and nothing will deploy.
+3. If `.adforge/state.json` exists, summarise what's deployed:
    - number of active campaigns, adsets, ads on Meta
    - the most recent report from `.adforge/reports/` if any
-3. Ask the user what they want to do. Keep it one short menu:
+4. Ask the user what they want to do. Keep it one short menu:
 
 ```
 You have <N> campaigns live. What do you want to do?
@@ -26,7 +27,7 @@ You have <N> campaigns live. What do you want to do?
 (tell me the number or type what you want in your own words)
 ```
 
-4. Based on the answer, load the matching sub-skill:
+5. Based on the answer, load the matching sub-skill:
    - 1 → `new-campaign`
    - 2 → `add-creative`
    - 3 → `review-performance`

--- a/templates/.claude/skills/new-campaign/SKILL.md
+++ b/templates/.claude/skills/new-campaign/SKILL.md
@@ -5,7 +5,17 @@ description: End-to-end flow for a brand-new campaign — angle, copy, assets, d
 
 # new-campaign
 
-Walk the user from a fresh idea to a PAUSED campaign on Meta. Four stages:
+Walk the user from a fresh idea to a PAUSED campaign on Meta. Four stages.
+
+## 0. Keys check (non-negotiable, runs first)
+
+Before you interview, before you draft angles, check `.env`:
+
+- No `.env` at all → route to `setup` skill, don't proceed.
+- No `BFL_API_KEY` → hero generation will fall back to `flat_brand_color`. Warn the user before briefing ("creatives will use flat brand-color backgrounds, not AI-generated heroes — set BFL_API_KEY in .env if you want FLUX heroes"). Let them decide: proceed without, or pause to add the key.
+- No `META_ACCESS_TOKEN` → everything renders locally, but `deploy.py` will only run `--dry-run`. Tell the user they'll need to upload manually or set the token before Stage 4.
+
+Skipping this check is how you end up generating twelve assets with wrong defaults that have to be thrown away.
 
 ## 1. Brief
 

--- a/templates/.claude/skills/setup/SKILL.md
+++ b/templates/.claude/skills/setup/SKILL.md
@@ -1,37 +1,74 @@
 ---
 name: setup
-description: First-time onboarding — brand tokens, API keys, font files, dry-run verification. Invoked from hub when state is empty or user asks for setup.
+description: First-time onboarding — API keys, brand tokens, font files, dry-run verification. Invoked from hub when .env is missing or user asks for setup.
 ---
 
 # setup
 
-Onboard a new user. Everything local, no API calls until the very end.
+Onboard a new user. Keys first (so FLUX and Meta work downstream), then brand and fonts, then a dry-run to prove the pipeline renders.
 
 ## 1. Check runtime
 
-Run `adforge doctor` (or the equivalent checks inline): node 18+, python3, pip, ffmpeg. Missing → tell the user what to install.
+Run `adforge doctor` (or the equivalent checks inline): Node 18+, Python 3, pip, ffmpeg, and Playwright (for brand extraction from JS-rendered sites). Missing → tell the user what to install. Playwright is optional but strongly recommended — without it, brand extraction falls back to plain HTML and breaks on any modern site.
 
-## 2. Brand
+## 2. API keys — first thing, before anything else renders
 
-Open `brand.json`. Walk the user through customising:
+If `.env` is missing but `.env.example` exists, copy it: `cp .env.example .env`. Then open `.env` and walk through keys **one at a time**. Never echo secrets back, never write values yourself — only the user fills them. Your job is to explain what each key is and where to find it.
 
-- name, wordmark, domain
-- colors (ink, muted, cream, accent) — accept hex or ask "paste your brand guidelines"
+For every key, if the user asks "was ist das" or "where do I get that", walk them through the exact click-path below. Do not skim.
+
+### `BFL_API_KEY` (optional — unlocks FLUX hero images)
+
+- What it is: Black Forest Labs API key. Without it, creatives render with flat brand-color backgrounds instead of generated hero images.
+- Where to get it: https://dashboard.bfl.ai → sign up → API Keys → Create Key. Pay-as-you-go, ~1ct per image.
+- If skipped: creatives still render, just with `hero_mode: "flat_brand_color"`. Fine for MVP, upgrade later.
+
+### `META_ACCESS_TOKEN` (required for deploy)
+
+- What it is: long-lived access token for the Meta Marketing API.
+- Where to get it:
+  1. https://business.facebook.com → Settings → Users → System Users → Add.
+  2. Give the system user the `ads_management`, `ads_read`, `business_management`, `pages_show_list`, `pages_manage_ads` scopes.
+  3. Assign it to your Ad Account (Settings → Accounts → Ad Accounts → Assign Partners / People).
+  4. Back on the System User → Generate New Token → pick the app → select the scopes above → copy the token.
+- Scopes: `ads_management` is the critical one. Without it, every deploy call 403s.
+
+### `META_AD_ACCOUNT_ID` (required for deploy)
+
+- What it is: your Meta ad account ID, prefixed with `act_`.
+- Where to get it: https://business.facebook.com → Ads Manager → the URL contains `act=1234...`, or Settings → Ad Accounts → Account ID. Format: `act_1234567890`.
+
+### `META_PAGE_ID` (required for deploy)
+
+- What it is: the Facebook Page the ads run from.
+- Where to get it: open your FB page → About tab → scroll to "Page transparency" or "Page ID" near the bottom.
+
+### `META_PIXEL_ID` (optional — only for conversion-optimized campaigns)
+
+- What it is: Meta Pixel ID, needed when optimisation goal is `OFFSITE_CONVERSIONS` (e.g. Lead or Purchase).
+- Where to get it: https://business.facebook.com → Events Manager → Data Sources → pick your pixel → ID in the top-right.
+- If skipped: traffic-optimized campaigns still work; conversion-optimized adsets will fail on deploy.
+
+When done, confirm each key is present (grep-test the `.env` file, don't echo values). Flag which optional keys are missing and what that limits.
+
+## 3. Brand
+
+Extract brand tokens from the user's domain. Use Playwright first (handles JS-rendered sites — most modern sites won't give you usable CSS via plain fetch). Fallback order:
+
+1. `playwright` via Python: launch headless Chromium, navigate, read computed styles of `h1`, primary button, body.
+2. Screenshot + vision parse if computed styles are inconclusive.
+3. `curl` + HTML scrape only if Playwright isn't installed — warn the user this will be wrong on most modern sites.
+
+Then open `brand.json` and walk the user through customising:
+- name, wordmark, domain, `locale` (AT for .at domains, DE for .de, ask if .com or ambiguous)
+- colors (ink, muted, cream, accent) — hex only
 - voice principles (1–3 short rules)
 
 Show the diff before writing.
 
-## 3. Fonts
+## 4. Fonts
 
-Tell the user: drop `.ttf` files into `./fonts/` matching the names in `brand.json`, or change the names in `brand.json` to match files they already have. Defaults are Google Fonts (Instrument Serif, JetBrains Mono, Inter).
-
-## 4. API keys
-
-Open `.env.example`, ask for values one at a time. Write `.env`. Never echo secrets back. Required:
-
-- `BFL_API_KEY` — for hero image generation (optional, can skip)
-- `META_ACCESS_TOKEN`, `META_AD_ACCOUNT_ID`, `META_PAGE_ID` — for deploy
-- `META_PIXEL_ID` — only if using conversion-optimized adsets
+Tell the user: drop `.ttf` files into `./fonts/` matching the names in `brand.json`, or change the names in `brand.json` to match files they already have. Defaults are Google Fonts (Instrument Serif, JetBrains Mono, Inter) — link them to https://fonts.google.com.
 
 ## 5. Dry-run
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -36,7 +36,7 @@ Mode skills compose 3 backend skills:
 
 - Never call the Meta API without explicit user approval for that specific action.
 - Always `--dry-run` before a live deploy.
-- Never write `.env`. Ask the user to write it themselves.
+- Copying `.env.example` → `.env` is fine and expected on first setup; never write secret **values** — the user fills those in. Never echo secrets back.
 - Show file diffs before writing any user-content file (variants, plan JSONs).
 - Skills are markdown — follow them as instructions, not as templates to quote back.
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -110,6 +110,28 @@ else
   pass "doctor ran (non-zero exit tolerated)"
 fi
 
+# Doctor output must mention Playwright (optional check for brand extraction).
+if grep -qi "playwright" "$WORK/doctor.log"; then
+  pass "doctor mentions playwright"
+else
+  fail "doctor output missing playwright check"
+fi
+
+# .env.example must carry all keys we promise in the README.
+ENV_EX="$PROJECT/.env.example"
+missing_keys=0
+for key in BFL_API_KEY META_ACCESS_TOKEN META_AD_ACCOUNT_ID META_PAGE_ID META_PIXEL_ID; do
+  if ! grep -q "^${key}=" "$ENV_EX"; then
+    echo "    missing key in .env.example: $key"
+    missing_keys=$((missing_keys+1))
+  fi
+done
+if [ $missing_keys -eq 0 ]; then
+  pass ".env.example has all 5 keys"
+else
+  fail ".env.example missing $missing_keys keys"
+fi
+
 # ---------------------------------------------------------------------------
 # Test 2 — static compose (advertorial example, 4x5)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Addresses three related setup-flow bugs surfaced in live test:
- **#4** Setup skipped API keys / AGENTS.md contradicted the skill / no auto-`.env` / no per-key explainer
- **#5** Brand extraction used plain HTML fetch, failed on every modern JS-rendered site
- **#8** Keys were requested in step 4 but variant generation ran in 2–3 → all hero images landed on fallback modes and no FLUX call ever happened

## Changes

### Setup SKILL
- Keys become **step 2**, before brand and fonts.
- Per-key click-path walkthrough for every key in `.env.example` (Meta Access Token path through Business Manager with exact scopes, Ad Account / Page / Pixel IDs, BFL API key).
- Auto-copy `.env.example` → `.env` if missing. Values remain user-provided.
- Brand extraction is Playwright-first; `curl` fetch only as last resort with a warning.

### new-campaign SKILL
- New **step 0 keys check** runs before the interview. Missing `BFL_API_KEY` → explicit warning about flat-color fallback. Missing `META_ACCESS_TOKEN` → deploy will be dry-run only.

### adforge hub SKILL
- When `.env` is missing, routes directly into `setup` instead of showing the menu.

### AGENTS.md
- Reconciled the "never write `.env`" contradiction. Copying the example file is fine; writing secret values is not.

### doctor
- Non-fatal Playwright probe with `pip install playwright && playwright install chromium` hint.

### Tests
- Assert `doctor` output mentions Playwright.
- Assert `.env.example` carries all 5 keys (BFL + 4 Meta).

## Test plan
- [x] `./test/run-tests.sh --skip-motion` → 11/11 pass
- [x] Fresh scaffold; `adforge doctor` shows Playwright row
- [x] `.env.example` present with all 5 keys after init