### PR TITLE
chore: CI, contributing guide, issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,61 @@
+name: Bug report
+description: Something in adforge broke or behaves unexpectedly
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: One or two sentences on the observed behaviour.
+      placeholder: e.g. `npx adforge init foo` exits 0 but the `variants/` folder is empty.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Repro steps
+      description: Minimal steps to reproduce. Please include the exact commands you ran.
+      placeholder: |
+        1. npx adforge init demo
+        2. cd demo
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: adforge version
+      description: Output of `npx adforge --version`
+      placeholder: "0.1.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Agent you were using
+      options:
+        - Claude Code
+        - Codex CLI
+        - Cursor
+        - Other / none
+    validations:
+      required: true
+
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: OS, Node, Python, ffmpeg versions (run `adforge doctor`).
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion
+    url: https://github.com/JonnyFi/adforge/discussions
+    about: Questions, ideas, design chats — use Discussions, not Issues.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: New engine, new adapter, or a change to existing behaviour
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's the problem
+      description: What are you trying to do that adforge doesn't let you do today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: If you have a concrete idea of how it should work. Skip if you just want to surface the pain.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - New engine (static or motion)
+        - New adapter (non-Meta channel)
+        - Skill / agent UX
+        - Meta adapter features
+        - Scaffold / init
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+    validations:
+      required: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: test
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: run test harness (skip motion render)
+        run: ./test/run-tests.sh --skip-motion

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thanks for poking at adforge. It's early — bugs and rough edges are expected, PRs to fix them are welcome.
+
+## Ways to contribute
+
+- **Bug reports** — open an issue with repro steps. Templates under `.github/ISSUE_TEMPLATE/`.
+- **New engines** — drop a renderer in `templates/engines/`, register it in `adforge.config.json`. Skills pick it up automatically.
+- **New adapters** — same pattern, but in `templates/adapters/`. Right now only Meta exists; TikTok / LinkedIn / Google would all slot in here.
+- **Skill improvements** — the `.claude/skills/` markdown is the brain of the agent. Small wording tweaks can change the whole UX.
+
+## Dev setup
+
+```bash
+git clone https://github.com/JonnyFi/adforge && cd adforge
+npm link                              # makes `adforge` resolve to your checkout
+./test/run-tests.sh --skip-motion     # run the harness
+```
+
+The test harness scaffolds a fresh project into `/tmp/adforge-tests`, fetches open-source fonts, renders a static advertorial, and (optionally) a motion render. It takes ~30s with `--skip-motion`, ~3min with full motion.
+
+Requirements: Node 18+, Python 3 with Pillow, ffmpeg. Playwright is optional but recommended for brand extraction.
+
+## Pull requests
+
+- Branch off `main`.
+- One PR per logical change. Small PRs are easier to review and ship.
+- Run `./test/run-tests.sh --skip-motion` before opening the PR. CI runs it anyway, but failing locally first saves a round-trip.
+- Commit messages: `fix(<area>): short line` or `feat(<area>): short line`, with a body explaining the *why* if non-obvious.
+- Don't add Co-Authored-By trailers for trivial changes (typos, version bumps, formatting).
+
+## What gets merged fast
+
+- Bug fixes with a failing-then-passing test
+- Documentation/README clarifications
+- New engines / adapters that follow the existing registry pattern
+
+## What needs a conversation first
+
+- Breaking changes to scaffold structure
+- New required API keys
+- Changes to the skill prompts that alter agent behaviour in non-trivial ways
+
+Open an issue with a proposal before spending time on any of those.
+
+## Licence
+
+MIT, same as the rest of the repo. By contributing, you agree your contribution is released under the same licence.


### PR DESCRIPTION
## Summary
Repo plumbing to prepare for opening to contributors.

## Changes
- **GitHub Actions** (`.github/workflows/test.yml`): runs `./test/run-tests.sh --skip-motion` on every PR and push to main. Finishes in ~30s on ubuntu-latest with Node 20 + Python 3.12 + ffmpeg.
- **CONTRIBUTING.md**: dev setup, PR guidelines, what merges fast vs needs a proposal first.
- **Issue templates** (`.github/ISSUE_TEMPLATE/`): structured bug and feature forms; config routes questions to Discussions.

## Notes
- Branch protection (Ruleset) on `main` is already live: require PR, block force-push, block deletion, 0 required approvals, admin bypass for the maintainer.
- Once this PR merges, the `test` workflow shows up in future PRs as a status check. After one clean run, we can optionally add `test` as a required status check to the ruleset.

## Test plan
- [x] Workflow YAML lints (GitHub will validate on push)
- [x] `./test/run-tests.sh --skip-motion` passes locally (already green on PR 2)