### PR TITLE
fix: creative defaults — flat brand, no CTA, asset-aware placements

### DIFF
--- a/templates/.claude/skills/composer-speccer/SKILL.md
+++ b/templates/.claude/skills/composer-speccer/SKILL.md
@@ -9,7 +9,7 @@ Turn a creative brief (from `creative-director`) into a valid variant JSON under
 
 ## Inputs
 
-- Angle + hook + body + CTA from creative-director
+- Angle + hook + body from creative-director
 - `adforge.config.json` (engines and layouts available)
 - User's format choice(s)
 
@@ -29,16 +29,22 @@ For `engine: "static"`, add: `layout` (one of `advertorial`, `stat-card`, `quote
 
 For `engine: "motion"`, add: `composition` (`ops-console`, `product-mockup`, `walkthrough`) and a `variant` object with the composition's expected shape (see `engines/motion/src/engines/<Name>.tsx` for the type).
 
+## Defaults — follow unless user asks otherwise
+
+- **`formats`: `["4x5", "9x16"]`** — 4x5 goes to Feed (FB + IG), 9x16 goes to Stories (and Reels for motion). Never default to 1x1 (legacy placement, downranked). Never ship only one format "for later" — Meta's delivery rewards multi-placement from day one.
+- **`hero_mode`: `"flat_brand_color"`** — clean brand-color background, works without FLUX or stock images. Use `radiant_gradient` as an explicit stylistic choice; `background` or `top_band` if the user provides a photo; only use `background` with a FLUX-generated hero if `BFL_API_KEY` is set and the user asked for it.
+- **`cta`: omit or `""`** — Meta has a platform CTA button on every ad unit. An in-creative CTA text is redundant in most cases, and adds a second focal point that fights the platform button. Only include an in-creative `cta` if the user explicitly asks for one (e.g. stylistic "learn more" link under a pull-quote, or when the layout has no other bottom element).
+
 ## Process
 
 1. Pick a unique `id` — ask the user to confirm.
-2. Draft the JSON. Keep text in whatever language/locale the brief used.
+2. Draft the JSON with the defaults above. Keep text in whatever language/locale the brief used.
 3. Show the diff before writing.
 4. For motion variants that need screenshots (walkthrough): ask the user where the images live. Copy them to `engines/motion/public/<subdir>/` and reference with just the subpath. Before picking click-target coordinates, open each screenshot and identify UI elements visually — don't make the user figure out pixel coordinates.
 5. Write the file, then tell the caller (`new-campaign` / `add-creative`) which compose command to run.
 
 ## Rules
 
-- Never invent hero images. If the brief implies a photo but none is specified, either use `hero_mode: "radiant_gradient"` or prompt-engineer a flux call and ask the user to run it.
+- Never invent hero images. If the brief implies a photo but none is specified: use `hero_mode: "flat_brand_color"` (new default), or if `BFL_API_KEY` is set and the user wants it, prompt-engineer a flux call and ask the user to run it.
 - Respect brand colors already in `brand.json` — don't override in variants unless the user explicitly asks.
 - Stat-card numbers must be sourced. No numbers without a `source` field.

--- a/templates/.claude/skills/new-campaign/SKILL.md
+++ b/templates/.claude/skills/new-campaign/SKILL.md
@@ -34,10 +34,18 @@ Load the `creative-director` skill. It proposes 3 angles with hooks and copy dra
 
 ## 3. Assets
 
-For each angle variant, load the `composer-speccer` skill to translate the copy brief into a concrete variant JSON under `variants/`. Then:
+For each angle variant, load the `composer-speccer` skill to translate the copy brief into a concrete variant JSON under `variants/`.
 
-- **static:** `python3 engines/static/compose.py variants/<id>.json <format> outputs/static/<id>_<format>.png`
-- **motion:** `./engines/motion/render.sh variants/<id>.json <composition> outputs/motion/<id>.mp4`
+**Format defaults — propose from day one, don't stage rollouts:**
+
+- Render **both `4x5` and `9x16`** for every variant. 4x5 serves Feed (FB + IG); 9x16 serves Stories (and Reels for motion). Meta's delivery rewards multi-placement coverage — launching Feed-only "to see how it does first" is a weaker start, not a safer one.
+- Never default to `1x1` (legacy square) — it's downranked across placements.
+- Don't ask "should we also do Stories?" as an opt-in. The user can opt *out* if they explicitly don't want a placement, but multi-format is the default.
+
+Render commands:
+
+- **static:** `python3 engines/static/compose.py variants/<id>.json <format> outputs/static/<id>_<format>.png` (run once per format)
+- **motion:** `./engines/motion/render.sh variants/<id>.json <composition> outputs/motion/<id>.mp4` (motion renders format-agnostic; the composition defines the aspect)
 
 Show the user the rendered files and let them approve/reject before deploy.
 

--- a/templates/adapters/meta/deploy.py
+++ b/templates/adapters/meta/deploy.py
@@ -46,6 +46,41 @@ def find_project_root(start):
     raise SystemExit("no adforge.config.json found")
 
 
+def derive_placements(ads):
+    """Return Meta placement fields based on asset types/formats in an adset.
+
+    Rules (tuned for brand-feeling ads, not spray-and-pray):
+      - static 4x5   → Feed (FB + IG)
+      - static 9x16  → Stories only (no Reels — static in Reels looks cheap)
+      - motion 4x5   → Feed
+      - motion 9x16  → Reels + Stories
+    Audience Network and Messenger are excluded by default (low-quality placements
+    for most B2B/mid-consideration funnels). Callers can override by setting
+    `publisher_platforms` / `facebook_positions` / `instagram_positions` on the
+    adset's `targeting` directly — in that case `derive_placements` is skipped.
+    """
+    fb_positions = set()
+    ig_positions = set()
+    for ad in ads:
+        fmt = ad.get("format", "4x5")
+        is_video = ad.get("creative_type") == "video"
+        if fmt == "4x5":
+            fb_positions.add("feed")
+            ig_positions.add("stream")
+        elif fmt == "9x16":
+            fb_positions.add("story")
+            ig_positions.add("story")
+            if is_video:
+                fb_positions.add("facebook_reels")
+                ig_positions.add("reels")
+    out = {"publisher_platforms": ["facebook", "instagram"]}
+    if fb_positions:
+        out["facebook_positions"] = sorted(fb_positions)
+    if ig_positions:
+        out["instagram_positions"] = sorted(ig_positions)
+    return out
+
+
 def state_load(path):
     if path.exists():
         return json.loads(path.read_text())
@@ -135,6 +170,9 @@ def deploy(plan, state, meta, project_root, page_id, pixel_id):
                 print(f"  [skip] adset '{aname}' ({aid})")
             else:
                 print(f"  [create] adset '{aname}'")
+                targeting = dict(adset["targeting"])
+                if "publisher_platforms" not in targeting:
+                    targeting.update(derive_placements(adset.get("ads", [])))
                 adset_data = {
                     "name": aname,
                     "campaign_id": cid,
@@ -142,7 +180,7 @@ def deploy(plan, state, meta, project_root, page_id, pixel_id):
                     "billing_event": adset.get("billing_event", "IMPRESSIONS"),
                     "optimization_goal": adset["optimization_goal"],
                     "bid_strategy": adset.get("bid_strategy", "LOWEST_COST_WITHOUT_CAP"),
-                    "targeting": json.dumps(adset["targeting"]),
+                    "targeting": json.dumps(targeting),
                     "status": adset.get("status", "PAUSED"),
                 }
                 if "destination_type" in adset:

--- a/templates/adapters/meta/example-plan.json
+++ b/templates/adapters/meta/example-plan.json
@@ -20,9 +20,21 @@
           },
           "ads": [
             {
-              "name": "adforge-demo-core-AT-advertorial-v1",
+              "name": "adforge-demo-core-AT-advertorial-4x5",
               "creative_type": "image",
+              "format": "4x5",
               "image_path": "outputs/static/example_4x5.png",
+              "primary_text": "The primary text lives here — short, plain, concrete.",
+              "headline": "Short headline",
+              "description": "Short description.",
+              "link": "https://example.com",
+              "cta_type": "LEARN_MORE"
+            },
+            {
+              "name": "adforge-demo-core-AT-advertorial-9x16",
+              "creative_type": "image",
+              "format": "9x16",
+              "image_path": "outputs/static/example_9x16.png",
               "primary_text": "The primary text lives here — short, plain, concrete.",
               "headline": "Short headline",
               "description": "Short description.",

--- a/templates/engines/static/compose.py
+++ b/templates/engines/static/compose.py
@@ -156,13 +156,14 @@ def build_readability_halo(size, brand, strength=0.85):
 
 
 def base_canvas(size, variant, brand):
-    hero_mode = variant.get("hero_mode", "radiant_gradient")
+    hero_mode = variant.get("hero_mode", "flat_brand_color")
     hero_path = variant.get("hero_image")
     if hero_path and not Path(hero_path).is_absolute():
         hero_path = str(Path.cwd() / hero_path)
     W, H = size
     canvas = Image.new("RGB", (W, H), brand.cream)
     band_h = 0
+    # flat_brand_color leaves the default cream fill alone — no-op branch
     if hero_mode == "background" and hero_path:
         bg = Image.open(hero_path).convert("RGB")
         canvas = crop_cover(bg, W, H)
@@ -290,8 +291,8 @@ def layout_advertorial(canvas, variant, brand, size, band_h):
             cursor_y += body_lh
     cursor_y += 40
 
-    # CTA
-    cta = variant.get("cta")
+    # CTA (opt-in only — Meta's platform CTA button is primary)
+    cta = variant.get("cta", "").strip() if variant.get("cta") else ""
     if cta:
         cta_bbox = draw.textbbox((0, 0), cta, font=cta_font)
         cta_w = cta_bbox[2] - cta_bbox[0]
@@ -305,8 +306,8 @@ def layout_advertorial(canvas, variant, brand, size, band_h):
     if byline:
         draw.text((pad_x, H - pad_bottom - byline_size), byline, font=byline_font, fill=brand.muted)
 
-    # bottom signature for radiant mode
-    if variant.get("hero_mode") == "radiant_gradient" and brand.wordmark:
+    # bottom signature when the lower canvas is otherwise empty (flat / gradient)
+    if variant.get("hero_mode", "flat_brand_color") in ("flat_brand_color", "radiant_gradient") and brand.wordmark:
         mono_small = brand.font("mono_medium", 36)
         wordmark_font = brand.font("serif_italic", 72)
         rule_y = H - pad_bottom - 120
@@ -384,7 +385,7 @@ def layout_quote_card(canvas, variant, brand, size, band_h):
     stamp_y = H - pad_bottom - 40
     if brand.wordmark:
         draw.text((pad_x, stamp_y), brand.wordmark, font=wordmark_font, fill=brand.accent)
-    cta = variant.get("cta")
+    cta = variant.get("cta", "").strip() if variant.get("cta") else ""
     if cta:
         cta_bbox = draw.textbbox((0, 0), cta, font=cta_font)
         cta_w = cta_bbox[2] - cta_bbox[0]

--- a/templates/variants/quote-card-example.json
+++ b/templates/variants/quote-card-example.json
@@ -6,6 +6,5 @@
   "context": "What operators said",
   "headline": "\"I used to brief a designer every Monday. Now I brief the agent.\"",
   "headline_highlight_phrase": "brief the agent",
-  "cta": "try adforge",
-  "hero_mode": "radiant_gradient"
+  "hero_mode": "flat_brand_color"
 }

--- a/templates/variants/stat-card-example.json
+++ b/templates/variants/stat-card-example.json
@@ -8,5 +8,5 @@
   "label": "of teams ship new creative in under 24h once adforge is set up.",
   "support": "Measured across 12 teams using brief-to-live workflow. Median time-to-first-ad: 5h.",
   "source": "ADFORGE BENCHMARK · INTERNAL",
-  "hero_mode": "radiant_gradient"
+  "hero_mode": "flat_brand_color"
 }

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -232,6 +232,69 @@ fi
 deactivate
 
 # ---------------------------------------------------------------------------
+# Test 2c — derive_placements + CTA-less render regression
+# ---------------------------------------------------------------------------
+head "Test 2c: creative defaults (placements + no-CTA)"
+
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+
+# derive_placements: static 4x5 -> Feed, static 9x16 -> Stories (no Reels),
+# motion 9x16 -> Reels + Stories. Runs directly against the template module.
+if python3 - <<PY > "$WORK/placements.log" 2>&1
+import sys
+sys.path.insert(0, "$PROJECT/adapters/meta")
+from deploy import derive_placements
+
+cases = [
+    ([{"creative_type": "image", "format": "4x5"}],
+     {"fb": ["feed"], "ig": ["stream"]}),
+    ([{"creative_type": "image", "format": "9x16"}],
+     {"fb": ["story"], "ig": ["story"]}),
+    ([{"creative_type": "video", "format": "9x16"}],
+     {"fb": ["facebook_reels", "story"], "ig": ["reels", "story"]}),
+    ([{"creative_type": "image", "format": "4x5"},
+      {"creative_type": "image", "format": "9x16"}],
+     {"fb": ["feed", "story"], "ig": ["story", "stream"]}),
+]
+for ads, want in cases:
+    got = derive_placements(ads)
+    assert got["publisher_platforms"] == ["facebook", "instagram"], got
+    assert got["facebook_positions"] == want["fb"], (got, want)
+    assert got["instagram_positions"] == want["ig"], (got, want)
+print("ok")
+PY
+then
+  pass "derive_placements matches expected matrix"
+else
+  fail "derive_placements unit test"
+  cat "$WORK/placements.log"
+fi
+
+# Render the quote-card example (no cta field) to prove the CTA guard works.
+OUT_NOCTA="$PROJECT/outputs/static/quote-card_4x5.png"
+if python3 "$PROJECT/engines/static/compose.py" \
+     "$PROJECT/variants/quote-card-example.json" 4x5 "$OUT_NOCTA" > "$WORK/compose-nocta.log" 2>&1; then
+  pass "compose without cta exited 0"
+else
+  fail "compose without cta exit code"
+  tail -30 "$WORK/compose-nocta.log"
+fi
+
+if [ -f "$OUT_NOCTA" ]; then
+  size=$(wc -c < "$OUT_NOCTA" | tr -d ' ')
+  if [ "$size" -gt 20000 ]; then
+    pass "no-cta PNG exists (${size} bytes)"
+  else
+    fail "no-cta PNG too small (${size} bytes)"
+  fi
+else
+  fail "no no-cta PNG produced"
+fi
+
+deactivate
+
+# ---------------------------------------------------------------------------
 # Test 3 — motion render (ops-console example)
 # ---------------------------------------------------------------------------
 if [ $SKIP_MOTION -eq 1 ]; then


### PR DESCRIPTION
## Summary

Three defaults tuned after a live-test pass surfaced weak creative out of the box.

- **`hero_mode` default → `flat_brand_color`** (was `radiant_gradient`). Renders the same with or without FLUX; no surprise empty gradients when `BFL_API_KEY` isn't set.
- **CTA-in-creative is opt-in, not default.** Meta's platform CTA button already lives on every ad unit — a second in-creative CTA fights it. `example.json` and `quote-card-example.json` drop the `cta` field; `compose.py` hardens the guard against empty/whitespace values.
- **Asset-aware placements in `deploy.py`.** New `derive_placements(ads)` replaces Meta's automatic placements (which pushes static into Reels + Audience Network). Matrix:
  - static 4x5 → Feed (FB + IG)
  - static 9x16 → Stories
  - motion 4x5 → Feed
  - motion 9x16 → Reels + Stories
  
  Users can still override by setting `publisher_platforms` on `targeting`.
- **`new-campaign` step 3** makes `4x5` + `9x16` the day-one default, not staged opt-ins.
- **`composer-speccer` skill** gets a new "Defaults" section spelling out why each default was chosen.

## Test plan

- [x] `./test/run-tests.sh --skip-motion` — all 14 tests pass
- [x] New Test 2c covers the `derive_placements` matrix (4 cases) and a CTA-less render regression
- [x] Dry-run state guard still clean