### PR TITLE
fix: TLD-based locale inference

### DIFF
--- a/templates/.claude/skills/setup/SKILL.md
+++ b/templates/.claude/skills/setup/SKILL.md
@@ -60,9 +60,31 @@ Extract brand tokens from the user's domain. Use Playwright first (handles JS-re
 3. `curl` + HTML scrape only if Playwright isn't installed — warn the user this will be wrong on most modern sites.
 
 Then open `brand.json` and walk the user through customising:
-- name, wordmark, domain, `locale` (AT for .at domains, DE for .de, ask if .com or ambiguous)
-- colors (ink, muted, cream, accent) — hex only
-- voice principles (1–3 short rules)
+- **name, wordmark, domain**. The domain is load-bearing — `adapters/meta/deploy.py` reads it to auto-default `geo_locations.countries` for every adset. See the TLD table below.
+- **colors** (ink, muted, cream, accent) — hex only.
+- **voice principles** (1–3 short rules) and **voice.locale** (copy language — `de`, `en`, `fr`, …). Derive from the same TLD mapping.
+
+**TLD → locale mapping** (same table `deploy.py::derive_locale` uses — apply deterministically, don't ask):
+
+| TLD | country | voice.locale |
+|-----|---------|--------------|
+| `.at` | AT | de |
+| `.de` | DE | de |
+| `.fr` | FR | fr |
+| `.es` | ES | es |
+| `.it` | IT | it |
+| `.nl` | NL | nl |
+| `.co.uk` / `.uk` | GB | en |
+| `.ie` | IE | en |
+| `.us` | US | en |
+| `.pl` | PL | pl |
+| `.pt` | PT | pt |
+| `.se` | SE | sv |
+| `.no` | NO | no |
+| `.dk` | DK | da |
+| `.fi` | FI | fi |
+
+**Ambiguous TLDs** (`.com`, `.io`, `.co`, `.app`, `.net`, `.ai`, `.ch`, `.be`, …) — *always* ask the user where they sell and what language they write in. `deploy.py` will refuse to auto-pick a country for these and require `targeting.geo_locations.countries` in the plan.
 
 Show the diff before writing.
 

--- a/templates/adapters/meta/deploy.py
+++ b/templates/adapters/meta/deploy.py
@@ -46,6 +46,60 @@ def find_project_root(start):
     raise SystemExit("no adforge.config.json found")
 
 
+# TLD → {country, language}. Unambiguous TLDs only — ambiguous ones (.com, .ch, …)
+# return None from derive_locale and force the caller to specify.
+TLD_LOCALE = {
+    "at": {"country": "AT", "language": "de"},
+    "de": {"country": "DE", "language": "de"},
+    "fr": {"country": "FR", "language": "fr"},
+    "es": {"country": "ES", "language": "es"},
+    "it": {"country": "IT", "language": "it"},
+    "nl": {"country": "NL", "language": "nl"},
+    "pl": {"country": "PL", "language": "pl"},
+    "pt": {"country": "PT", "language": "pt"},
+    "se": {"country": "SE", "language": "sv"},
+    "no": {"country": "NO", "language": "no"},
+    "dk": {"country": "DK", "language": "da"},
+    "fi": {"country": "FI", "language": "fi"},
+    "ie": {"country": "IE", "language": "en"},
+    "us": {"country": "US", "language": "en"},
+    "co.uk": {"country": "GB", "language": "en"},
+    "uk": {"country": "GB", "language": "en"},
+}
+
+
+def derive_locale(domain):
+    """Return {"country": "AT", "language": "de"} for unambiguous TLDs, else None.
+
+    Accepts bare domains, URLs, or www-prefixed strings. Strips path. Recognises
+    .co.uk as a two-label TLD. Returns None for generic TLDs (.com, .io, .co, …)
+    and multi-lingual country TLDs (.ch, .be) so callers must specify explicitly.
+    """
+    if not domain:
+        return None
+    d = domain.strip().lower()
+    for prefix in ("https://", "http://", "www."):
+        if d.startswith(prefix):
+            d = d[len(prefix):]
+    d = d.split("/")[0].split("?")[0]
+    if d.endswith(".co.uk"):
+        return TLD_LOCALE["co.uk"]
+    if "." not in d:
+        return None
+    tld = d.rsplit(".", 1)[-1]
+    return TLD_LOCALE.get(tld)
+
+
+def load_brand(project_root):
+    path = project_root / "brand.json"
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {}
+
+
 def derive_placements(ads):
     """Return Meta placement fields based on asset types/formats in an adset.
 
@@ -145,6 +199,8 @@ class Meta:
 
 def deploy(plan, state, meta, project_root, page_id, pixel_id):
     """Walk the plan and create everything that doesn't yet exist in state."""
+    brand = load_brand(project_root)
+    brand_locale = derive_locale(brand.get("domain", ""))
     for campaign in plan.get("campaigns", []):
         cname = campaign["name"]
         if cname in state["campaigns"]:
@@ -173,6 +229,15 @@ def deploy(plan, state, meta, project_root, page_id, pixel_id):
                 targeting = dict(adset["targeting"])
                 if "publisher_platforms" not in targeting:
                     targeting.update(derive_placements(adset.get("ads", [])))
+                if "geo_locations" not in targeting:
+                    if brand_locale:
+                        targeting["geo_locations"] = {"countries": [brand_locale["country"]]}
+                        print(f"    [locale] defaulted geo_locations.countries to ['{brand_locale['country']}'] from brand.domain")
+                    else:
+                        raise SystemExit(
+                            f"error: adset '{aname}' has no targeting.geo_locations and brand.json domain "
+                            f"({brand.get('domain', '<unset>')!r}) is ambiguous — set targeting.geo_locations.countries explicitly"
+                        )
                 adset_data = {
                     "name": aname,
                     "campaign_id": cid,

--- a/templates/brand.json
+++ b/templates/brand.json
@@ -28,7 +28,8 @@
       "no superlatives unless quantified"
     ],
     "audience": "describe your audience here",
-    "locale": "en"
+    "locale": "en",
+    "_comment": "voice.locale = copy language. Derive from the domain TLD during setup (.at/.de → de, .fr → fr, .com → ask). deploy.py auto-defaults targeting.geo_locations.countries from the same domain."
   },
   "radiant_gradient": {
     "top_color": [252, 240, 217],

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -301,6 +301,104 @@ fi
 deactivate
 
 # ---------------------------------------------------------------------------
+# Test 2d — TLD-based locale inference
+# ---------------------------------------------------------------------------
+head "Test 2d: TLD-based locale inference"
+
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+
+if python3 - <<PY > "$WORK/locale.log" 2>&1
+import sys
+sys.path.insert(0, "$PROJECT/adapters/meta")
+from deploy import derive_locale
+
+cases = {
+    "example.at": ("AT", "de"),
+    "https://example.at/path": ("AT", "de"),
+    "www.example.at": ("AT", "de"),
+    "example.de": ("DE", "de"),
+    "example.fr": ("FR", "fr"),
+    "example.co.uk": ("GB", "en"),
+    "example.us": ("US", "en"),
+}
+for domain, want in cases.items():
+    got = derive_locale(domain)
+    assert got == {"country": want[0], "language": want[1]}, (domain, got, want)
+
+ambiguous = ["example.com", "example.io", "example.co", "example.ch", "example.be", "", "noextension"]
+for domain in ambiguous:
+    assert derive_locale(domain) is None, f"{domain} should be ambiguous, got {derive_locale(domain)}"
+
+print("ok")
+PY
+then
+  pass "derive_locale matrix (unambiguous + ambiguous)"
+else
+  fail "derive_locale unit test"
+  cat "$WORK/locale.log"
+fi
+
+# Integration: plan with no geo_locations + brand.json with .at domain should
+# auto-default countries to ["AT"] during dry-run.
+PLAN_NO_GEO="$PROJECT/plan-no-geo.json"
+python3 - <<PY
+import json, pathlib
+p = json.loads(pathlib.Path("$PROJECT/adapters/meta/example-plan.json").read_text())
+for c in p["campaigns"]:
+    for a in c["adsets"]:
+        a["targeting"].pop("geo_locations", None)
+pathlib.Path("$PLAN_NO_GEO").write_text(json.dumps(p, indent=2))
+PY
+
+BRAND_BAK="$WORK/brand.json.bak"
+cp "$PROJECT/brand.json" "$BRAND_BAK"
+python3 - <<PY
+import json, pathlib
+path = pathlib.Path("$PROJECT/brand.json")
+b = json.loads(path.read_text())
+b["domain"] = "example.at"
+path.write_text(json.dumps(b, indent=2))
+PY
+
+if (cd "$PROJECT" && python3 adapters/meta/deploy.py --dry-run "$PLAN_NO_GEO" > "$WORK/locale-dry.log" 2>&1); then
+  if grep -q "defaulted geo_locations.countries to \['AT'\]" "$WORK/locale-dry.log"; then
+    pass "deploy auto-defaulted AT countries from brand.domain"
+  else
+    fail "deploy didn't log locale default"
+    tail -20 "$WORK/locale-dry.log"
+  fi
+else
+  fail "dry-run with missing geo failed unexpectedly"
+  tail -30 "$WORK/locale-dry.log"
+fi
+
+# Ambiguous domain (.com) must refuse to auto-pick and error clearly.
+python3 - <<PY
+import json, pathlib
+path = pathlib.Path("$PROJECT/brand.json")
+b = json.loads(path.read_text())
+b["domain"] = "example.com"
+path.write_text(json.dumps(b, indent=2))
+PY
+
+if (cd "$PROJECT" && python3 adapters/meta/deploy.py --dry-run "$PLAN_NO_GEO" > "$WORK/locale-dry-ambig.log" 2>&1); then
+  fail "deploy should have errored on ambiguous domain + missing geo_locations"
+  tail -20 "$WORK/locale-dry-ambig.log"
+else
+  if grep -qi "ambiguous" "$WORK/locale-dry-ambig.log"; then
+    pass "deploy refused ambiguous domain with clear error"
+  else
+    fail "deploy errored but message didn't mention ambiguous"
+    tail -20 "$WORK/locale-dry-ambig.log"
+  fi
+fi
+
+cp "$BRAND_BAK" "$PROJECT/brand.json"
+
+deactivate
+
+# ---------------------------------------------------------------------------
 # Test 3 — motion render (ops-console example)
 # ---------------------------------------------------------------------------
 if [ $SKIP_MOTION -eq 1 ]; then


### PR DESCRIPTION
## Summary

Closes v0.1.1 bug: deploy asked users to fill `geo_locations.countries` manually for every adset, even when a `.at` or `.de` domain made it obvious.

- `deploy.py` exports `derive_locale(domain)` — unambiguous TLDs map to `{country, language}`; generic TLDs (`.com`, `.io`, `.ch`, …) return `None`.
- When an adset omits `geo_locations`, `deploy.py` auto-defaults countries from `brand.json.domain`. Logs the inference explicitly.
- Ambiguous domains + missing `geo_locations` → clear SystemExit asking for explicit countries. No silent guess.
- `setup` SKILL now has the same TLD→locale table the code uses, so the agent fills `brand.json.voice.locale` deterministically.

## Test plan

- [x] `derive_locale` matrix test (unambiguous happy path — .at, .de, .fr, .co.uk, … — and ambiguous refusal — .com, .io, .ch, .be)
- [x] Dry-run integration: plan with stripped `geo_locations` + `brand.domain=example.at` → logs `[locale] defaulted geo_locations.countries to ['AT']`
- [x] Dry-run integration: same plan + `brand.domain=example.com` → errors with "ambiguous" in message
- [x] Full suite: 17/17 pass