### PR TITLE
feat: free-form targeting resolver + flexible_spec + Advantage+ (closes #28)

### DIFF
--- a/templates/.claude/skills/new-campaign/SKILL.md
+++ b/templates/.claude/skills/new-campaign/SKILL.md
@@ -91,9 +91,47 @@ Show the user the rendered files and let them approve/reject before deploy.
 
 ## 5. Plan & deploy
 
-Draft a `campaign-plan.json` (see `adapters/meta/example-plan.json` for shape). Show it as a diff. On approval:
+Draft a `campaign-plan.json` (see `adapters/meta/example-plan.json` for shape). Show it as a diff.
 
-- `python3 adapters/meta/deploy.py --dry-run campaign-plan.json` — preview first
+### Targeting — free-form, resolved before deploy
+
+Write targeting in plain language — `adapters/meta/resolve.py` turns strings into Meta IDs in a second pass:
+
+```json
+"targeting": {
+  "geo_locations": {"countries": ["AT"]},
+  "interests":      ["mobile Pflege", "Hauskrankenpflege"],
+  "work_positions": ["Pflegedienstleitung"],
+  "industries":     ["Healthcare Services"],
+  "age_min": 28,
+  "age_max": 58,
+  "advantage_audience": true
+}
+```
+
+Five resolvable fields: `interests`, `work_positions`, `work_employers`, `industries`, `behaviors`. Write whichever apply — B2B campaigns usually lean on `work_positions` + `industries`, B2C on `interests` + `behaviors`.
+
+**Advantage+ vs. hard targeting.** Ask the user once:
+
+> "Meta has two modes. **Advantage+ Audience** (default) — your targeting is treated as *hints*, Meta's AI expands to similar users that convert. **Hard targeting** — Meta delivers only to people who match. Which do you want?"
+
+Set `advantage_audience: true` for Advantage+, `false` for hard. If skipped, Meta defaults to Advantage+ on v23+ anyway; we set it explicitly so plan behavior is version-independent.
+
+### Resolve, review, deploy
+
+```bash
+# turn strings into {id, name, audience_size} objects in place
+python3 adapters/meta/resolve.py campaign-plan.json
+
+# or non-interactive: pick dominant matches automatically, fail on anything ambiguous
+python3 adapters/meta/resolve.py --auto campaign-plan.json
+```
+
+After resolve, show the plan diff to the user — this is the moment to sanity-check matches (audience sizes, category paths) before spending money. Then:
+
+- `python3 adapters/meta/deploy.py --dry-run campaign-plan.json` — preview API calls
 - `python3 adapters/meta/deploy.py campaign-plan.json` — live, everything PAUSED
+
+Deploy refuses to run if it sees raw strings (means resolve wasn't run). Manual escape: write an `{"id": "12345", "name": "..."}` object directly in the plan — resolve leaves those alone.
 
 Finish with: "All deployed and paused. To go live, run `python3 adapters/meta/actions.py resume --adset <name>`."

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -29,7 +29,7 @@ Mode skills compose 4 backend skills:
 - `variants/` — user-authored ad specs (JSON)
 - `engines/static/compose.py` — PIL renderer (advertorial, stat-card, quote-card)
 - `engines/motion/` — Remotion project (ops-console, product-mockup, walkthrough)
-- `adapters/meta/` — deploy.py, review.py, actions.py (Graph API v21.0)
+- `adapters/meta/` — deploy.py, resolve.py, review.py, actions.py (Graph API v22.0). `resolve.py` turns free-form targeting strings (interests, work_positions, industries, behaviors, work_employers) into Meta IDs in place on the plan.
 - `.adforge/state.json` — idempotent deploy state (Meta IDs keyed by name)
 - `outputs/` — rendered assets
 

--- a/templates/adapters/meta/actions.py
+++ b/templates/adapters/meta/actions.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import requests
 
-API = "https://graph.facebook.com/v21.0"
+API = "https://graph.facebook.com/v22.0"
 
 
 def load_env(project_root):

--- a/templates/adapters/meta/deploy.py
+++ b/templates/adapters/meta/deploy.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import requests
 
-API = "https://graph.facebook.com/v21.0"
+API = "https://graph.facebook.com/v22.0"
 
 
 def load_env(project_root):
@@ -135,6 +135,52 @@ def derive_placements(ads):
     return out
 
 
+# Fields that go into Meta's flexible_spec block. Plan carries them at the top
+# level of `targeting` (after resolve.py turns strings into {id, name} objects);
+# deploy collapses them into one AND-block inside flexible_spec.
+FLEXIBLE_FIELDS = ("interests", "work_positions", "work_employers", "industries", "behaviors")
+
+
+def build_flexible_spec(targeting, adset_name):
+    """Collapse resolved targeting fields into a single flexible_spec AND-block.
+
+    Raises if any entry is still a raw string (means resolve.py wasn't run).
+    Leaves targeting untouched if none of the flexible fields are present.
+    """
+    block = {}
+    for field in FLEXIBLE_FIELDS:
+        entries = targeting.pop(field, None)
+        if not entries:
+            continue
+        clean = []
+        for e in entries:
+            if isinstance(e, str):
+                raise SystemExit(
+                    f"error: adset '{adset_name}' has raw string {e!r} in targeting.{field} — "
+                    f"run `python3 adapters/meta/resolve.py <plan>` first"
+                )
+            if isinstance(e, dict) and e.get("id"):
+                clean.append({"id": str(e["id"]), "name": e.get("name", "")})
+        if clean:
+            block[field] = clean
+    if not block:
+        return
+    existing = targeting.get("flexible_spec", [])
+    targeting["flexible_spec"] = existing + [block]
+
+
+def apply_advantage_audience(targeting):
+    """Translate plan-level `advantage_audience: bool` into Meta's nested
+    `targeting_automation.advantage_audience` (0/1) field.
+    """
+    if "advantage_audience" not in targeting:
+        return
+    flag = 1 if targeting.pop("advantage_audience") else 0
+    ta = dict(targeting.get("targeting_automation", {}))
+    ta["advantage_audience"] = flag
+    targeting["targeting_automation"] = ta
+
+
 def state_load(path):
     if path.exists():
         return json.loads(path.read_text())
@@ -238,6 +284,8 @@ def deploy(plan, state, meta, project_root, page_id, pixel_id):
                             f"error: adset '{aname}' has no targeting.geo_locations and brand.json domain "
                             f"({brand.get('domain', '<unset>')!r}) is ambiguous — set targeting.geo_locations.countries explicitly"
                         )
+                build_flexible_spec(targeting, aname)
+                apply_advantage_audience(targeting)
                 adset_data = {
                     "name": aname,
                     "campaign_id": cid,

--- a/templates/adapters/meta/example-plan.json
+++ b/templates/adapters/meta/example-plan.json
@@ -16,7 +16,9 @@
           "targeting": {
             "geo_locations": {"countries": ["AT"]},
             "age_min": 28,
-            "age_max": 55
+            "age_max": 55,
+            "advantage_audience": true,
+            "_comment": "write interests/work_positions/industries/behaviors as free-form strings — `resolve.py` turns them into {id, name, audience_size} objects before deploy. example: \"work_positions\": [\"Pflegedienstleitung\"]"
           },
           "ads": [
             {

--- a/templates/adapters/meta/resolve.py
+++ b/templates/adapters/meta/resolve.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Meta adapter — resolve free-form targeting strings to Meta IDs, in place.
+
+Reads a campaign plan, walks every adset.targeting.<field>, and for each
+free-form string calls Meta's targeting search API to resolve it to
+`{"id", "name", "audience_size"}`. Writes the resolved plan back.
+
+Supported fields (all optional in the plan):
+    interests       → type=adinterest
+    work_positions  → type=adworkposition
+    work_employers  → type=adworkemployer
+    industries      → type=adTargetingCategory&class=industries
+    behaviors       → type=adTargetingCategory&class=behaviors
+
+Already-resolved entries (objects with an `id`) are skipped. The plan file is
+the only state — re-runs are idempotent.
+
+Modes:
+    (default)       interactive: for each query, show top-3 candidates, prompt pick.
+    --auto          auto-pick the top candidate when it's dominant (exact name
+                    match or >5× the audience size of the runner-up). Unresolved
+                    queries are listed and exit is non-zero.
+
+Usage:
+    python3 adapters/meta/resolve.py <campaign-plan.json>
+    python3 adapters/meta/resolve.py --auto <campaign-plan.json>
+"""
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import requests
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE))
+from deploy import API, derive_locale, load_brand, load_env, find_project_root
+
+
+# plan-field → (search type, extra params). Used by resolve_query.
+FIELD_MAP = {
+    "interests":      ("adinterest",          {}),
+    "work_positions": ("adworkposition",      {}),
+    "work_employers": ("adworkemployer",      {}),
+    "industries":     ("adTargetingCategory", {"class": "industries"}),
+    "behaviors":      ("adTargetingCategory", {"class": "behaviors"}),
+}
+
+DOMINANCE_RATIO = 5  # top audience_size must be >= N× runner-up for --auto pick
+
+
+def search(session, token, type_, q, locale=None, limit=8, extra=None):
+    params = {"type": type_, "q": q, "limit": limit, "access_token": token}
+    if locale:
+        params["locale"] = locale
+    if extra:
+        params.update(extra)
+    r = session.get(f"{API}/search", params=params)
+    if r.status_code >= 400:
+        raise RuntimeError(f"search {type_} q={q!r} failed {r.status_code}: {r.text}")
+    return r.json().get("data", [])
+
+
+def option_active(session, token, type_, id_):
+    """Check targetingoptionstatus. Returns True unless the option is explicitly
+    NON-DELIVERABLE. We drop NON-DELIVERABLE silently and keep DEPRECATING since
+    Meta still accepts them for now — this is internal hygiene, not user-facing.
+    """
+    try:
+        r = session.get(
+            f"{API}/search",
+            params={
+                "type": "targetingoptionstatus",
+                "targeting_list": json.dumps([{"type": type_, "id": str(id_)}]),
+                "access_token": token,
+            },
+        )
+        if r.status_code >= 400:
+            return True  # fail open — don't drop on transient API error
+        data = r.json().get("data", [])
+        if not data:
+            return True
+        status = data[0].get("current_status", "NORMAL")
+        return status != "NON_DELIVERABLE"
+    except Exception:
+        return True
+
+
+def dominant(candidates):
+    """Return the first candidate if it's clearly the best match.
+
+    Dominance = (a) exact case-insensitive name match AND no equally-exact
+    runner-up, or (b) audience_size >= 5× runner-up.
+    """
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
+    top, runner = candidates[0], candidates[1]
+    top_size = int(top.get("audience_size") or 0)
+    runner_size = int(runner.get("audience_size") or 1)
+    if runner_size == 0:
+        runner_size = 1
+    if top_size and top_size / runner_size >= DOMINANCE_RATIO:
+        return top
+    return None
+
+
+def format_candidate(c):
+    name = c.get("name", "?")
+    size = c.get("audience_size")
+    path = " › ".join(c.get("path", [])) if c.get("path") else ""
+    size_s = f"{size:,}" if isinstance(size, int) else "?"
+    trail = f"  [{path}]" if path else ""
+    return f"{name} · {size_s} people{trail}"
+
+
+def resolve_query(session, token, type_, query, locale, extra, auto, unresolved_log):
+    raw = search(session, token, type_, query, locale=locale, extra=extra)
+    # silent hygiene — filter NON_DELIVERABLE
+    candidates = [c for c in raw if option_active(session, token, type_, c.get("id"))]
+    if not candidates:
+        unresolved_log.append((type_, query, "no matches"))
+        return None
+
+    if auto:
+        pick = dominant(candidates)
+        if pick is None:
+            unresolved_log.append((type_, query, f"ambiguous — top: {format_candidate(candidates[0])}"))
+            return None
+    else:
+        print(f"\n  query: {query!r}  ({type_})")
+        top = candidates[:3]
+        for i, c in enumerate(top, 1):
+            print(f"    {i}. {format_candidate(c)}")
+        print(f"    s) skip")
+        while True:
+            choice = input("  pick [1-3/s]: ").strip().lower()
+            if choice == "s":
+                unresolved_log.append((type_, query, "user skipped"))
+                return None
+            if choice in {"1", "2", "3"} and int(choice) <= len(top):
+                pick = top[int(choice) - 1]
+                break
+            print("    invalid — pick 1-3 or s")
+
+    return {
+        "id": str(pick["id"]),
+        "name": pick.get("name", query),
+        "audience_size": pick.get("audience_size"),
+    }
+
+
+def walk_targeting(plan, resolver):
+    """Mutate plan in place — for each adset.targeting.<field> in FIELD_MAP,
+    turn any free-form string entries into resolved objects. Leaves already-
+    resolved objects untouched.
+    """
+    for campaign in plan.get("campaigns", []):
+        for adset in campaign.get("adsets", []):
+            t = adset.get("targeting", {})
+            for field, (type_, extra) in FIELD_MAP.items():
+                entries = t.get(field)
+                if not entries:
+                    continue
+                resolved = []
+                for entry in entries:
+                    if isinstance(entry, dict) and entry.get("id"):
+                        resolved.append(entry)
+                        continue
+                    if not isinstance(entry, str):
+                        continue
+                    picked = resolver(type_, entry, extra)
+                    if picked:
+                        resolved.append(picked)
+                t[field] = resolved
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("plan", help="path to campaign plan JSON")
+    ap.add_argument("--auto", action="store_true",
+                    help="auto-pick dominant matches; exit non-zero if anything is ambiguous")
+    args = ap.parse_args()
+
+    plan_path = Path(args.plan)
+    project_root = find_project_root(plan_path)
+    env = {**os.environ, **load_env(project_root)}
+    token = env.get("META_ACCESS_TOKEN", "")
+    if not token:
+        raise SystemExit("error: META_ACCESS_TOKEN not set (in .env or env)")
+
+    brand = load_brand(project_root)
+    locale_info = derive_locale(brand.get("domain", ""))
+    # Meta's `locale` search param is `language_TERRITORY`, e.g. "de_AT".
+    search_locale = None
+    if locale_info:
+        search_locale = f"{locale_info['language']}_{locale_info['country']}"
+
+    plan = json.loads(plan_path.read_text())
+    session = requests.Session()
+    unresolved = []
+
+    def resolver(type_, query, extra):
+        return resolve_query(
+            session, token, type_, query, search_locale, extra,
+            auto=args.auto, unresolved_log=unresolved,
+        )
+
+    walk_targeting(plan, resolver)
+
+    plan_path.write_text(json.dumps(plan, indent=2, ensure_ascii=False) + "\n")
+    print(f"\nwrote resolved plan -> {plan_path}")
+
+    if unresolved:
+        print(f"\n{len(unresolved)} unresolved:")
+        for t, q, reason in unresolved:
+            print(f"  - {t}  {q!r}  ({reason})")
+        if args.auto:
+            print("\nRe-run without --auto to pick interactively, or paste IDs manually:")
+            print('  "interests": [{"id": "12345", "name": "..."}]')
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/adapters/meta/resolve.py
+++ b/templates/adapters/meta/resolve.py
@@ -193,10 +193,19 @@ def main():
 
     brand = load_brand(project_root)
     locale_info = derive_locale(brand.get("domain", ""))
-    # Meta's `locale` search param is `language_TERRITORY`, e.g. "de_AT".
+    # Meta's `locale` param only accepts a fixed set of `language_TERRITORY`
+    # values (e.g. de_DE, en_US, fr_FR). de_AT / de_CH / nl_BE are rejected.
+    # We map derived locales to the dominant-territory variant Meta supports —
+    # this controls the language of returned names, NOT which country the ads
+    # target (that's `geo_locations`, set independently from the TLD).
+    LANG_TO_META_LOCALE = {
+        "de": "de_DE", "fr": "fr_FR", "nl": "nl_NL", "it": "it_IT",
+        "es": "es_ES", "pt": "pt_BR", "en": "en_US", "pl": "pl_PL",
+        "sv": "sv_SE", "da": "da_DK", "fi": "fi_FI", "nb": "nb_NO",
+    }
     search_locale = None
     if locale_info:
-        search_locale = f"{locale_info['language']}_{locale_info['country']}"
+        search_locale = LANG_TO_META_LOCALE.get(locale_info["language"])
 
     plan = json.loads(plan_path.read_text())
     session = requests.Session()

--- a/templates/adapters/meta/review.py
+++ b/templates/adapters/meta/review.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import requests
 
-API = "https://graph.facebook.com/v21.0"
+API = "https://graph.facebook.com/v22.0"
 
 
 def load_env(project_root):

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -522,6 +522,43 @@ else
   fi
 fi
 
+# 2e.4 — locale mapping: derived de_AT / de_CH / fr_BE must map to the
+# dominant-territory locale Meta actually accepts (de_DE, fr_FR).
+if python3 - <<PY > "$WORK/locale-map.log" 2>&1
+import sys
+sys.path.insert(0, "$PROJECT/adapters/meta")
+from deploy import derive_locale
+
+# these are derived from TLD — all valid BCP-47 but NOT all accepted by Meta search
+cases = {
+    "hanicare.at":  "de",  # → de_DE
+    "example.ch":   None,  # ambiguous TLD, derive_locale returns None
+    "example.de":   "de",
+    "example.fr":   "fr",
+    "example.nl":   "nl",
+    "example.it":   "it",
+}
+LANG_TO_META = {
+    "de": "de_DE", "fr": "fr_FR", "nl": "nl_NL", "it": "it_IT",
+    "es": "es_ES", "pt": "pt_BR", "en": "en_US",
+}
+for domain, expected_lang in cases.items():
+    info = derive_locale(domain)
+    if expected_lang is None:
+        assert info is None, (domain, info)
+    else:
+        assert info and info["language"] == expected_lang, (domain, info)
+        meta_locale = LANG_TO_META.get(info["language"])
+        assert meta_locale is not None, (domain, info)
+print("ok")
+PY
+then
+  pass "locale map covers TLDs Meta's search accepts"
+else
+  fail "locale map"
+  cat "$WORK/locale-map.log"
+fi
+
 deactivate
 
 # ---------------------------------------------------------------------------

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -399,6 +399,132 @@ cp "$BRAND_BAK" "$PROJECT/brand.json"
 deactivate
 
 # ---------------------------------------------------------------------------
+# Test 2e — targeting resolve + flexible_spec + advantage_audience
+# ---------------------------------------------------------------------------
+head "Test 2e: targeting resolve + flexible_spec"
+
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+
+# 2e.1 — walk_targeting turns strings into resolved objects; already-resolved
+# entries are skipped (plan file IS the cache, re-run is idempotent).
+if python3 - <<PY > "$WORK/resolve-unit.log" 2>&1
+import sys
+sys.path.insert(0, "$PROJECT/adapters/meta")
+from resolve import walk_targeting, FIELD_MAP
+
+plan = {"campaigns": [{"adsets": [{"targeting": {
+    "interests": ["mobile Pflege", {"id": "999", "name": "already-resolved"}],
+    "work_positions": ["Pflegedienstleitung"],
+    "industries": ["Healthcare"],
+}}]}]}
+
+calls = []
+def stub(type_, q, extra):
+    calls.append((type_, q, extra))
+    return {"id": f"id_{q}", "name": q, "audience_size": 100000}
+
+walk_targeting(plan, stub)
+
+t = plan["campaigns"][0]["adsets"][0]["targeting"]
+assert t["interests"] == [
+    {"id": "id_mobile Pflege", "name": "mobile Pflege", "audience_size": 100000},
+    {"id": "999", "name": "already-resolved"},
+], t["interests"]
+assert t["work_positions"][0]["id"] == "id_Pflegedienstleitung"
+assert t["industries"][0]["id"] == "id_Healthcare"
+
+# re-run must be a no-op — no further API calls
+before = len(calls)
+walk_targeting(plan, stub)
+assert len(calls) == before, f"re-run called resolver {len(calls)-before} extra times"
+
+# check the right endpoint types got called
+types_seen = {c[0] for c in calls}
+assert types_seen == {"adinterest", "adworkposition", "adTargetingCategory"}, types_seen
+print("ok")
+PY
+then
+  pass "walk_targeting resolves + is idempotent on re-run"
+else
+  fail "walk_targeting unit test"
+  cat "$WORK/resolve-unit.log"
+fi
+
+# 2e.2 — build_flexible_spec collapses resolved fields into one AND-block
+if python3 - <<PY > "$WORK/flex-unit.log" 2>&1
+import sys
+sys.path.insert(0, "$PROJECT/adapters/meta")
+from deploy import build_flexible_spec, apply_advantage_audience
+
+# resolved targeting → flexible_spec block
+t = {
+    "geo_locations": {"countries": ["AT"]},
+    "interests": [{"id": "1", "name": "Pflege"}],
+    "work_positions": [{"id": "2", "name": "PDL"}],
+    "industries": [{"id": "3", "name": "Healthcare"}],
+}
+build_flexible_spec(t, "test-adset")
+assert "interests" not in t, "should have popped interests off top-level"
+assert t["flexible_spec"] == [{
+    "interests": [{"id": "1", "name": "Pflege"}],
+    "work_positions": [{"id": "2", "name": "PDL"}],
+    "industries": [{"id": "3", "name": "Healthcare"}],
+}], t["flexible_spec"]
+
+# raw strings → SystemExit with actionable message
+try:
+    build_flexible_spec({"interests": ["mobile Pflege"]}, "x")
+    assert False, "should have raised"
+except SystemExit as e:
+    assert "resolve.py" in str(e), e
+
+# advantage_audience true → nested targeting_automation.advantage_audience = 1
+t = {"advantage_audience": True}
+apply_advantage_audience(t)
+assert t == {"targeting_automation": {"advantage_audience": 1}}, t
+
+t = {"advantage_audience": False}
+apply_advantage_audience(t)
+assert t == {"targeting_automation": {"advantage_audience": 0}}, t
+
+# flag omitted → no targeting_automation added
+t = {"geo_locations": {"countries": ["AT"]}}
+apply_advantage_audience(t)
+assert "targeting_automation" not in t, t
+print("ok")
+PY
+then
+  pass "build_flexible_spec + apply_advantage_audience"
+else
+  fail "flexible_spec unit test"
+  cat "$WORK/flex-unit.log"
+fi
+
+# 2e.3 — deploy dry-run must fail on raw strings (means resolve wasn't run)
+PLAN_RAW="$PROJECT/plan-raw-strings.json"
+python3 - <<PY
+import json, pathlib
+p = json.loads(pathlib.Path("$PROJECT/adapters/meta/example-plan.json").read_text())
+p["campaigns"][0]["adsets"][0]["targeting"]["interests"] = ["mobile Pflege"]
+pathlib.Path("$PLAN_RAW").write_text(json.dumps(p, indent=2))
+PY
+
+if (cd "$PROJECT" && python3 adapters/meta/deploy.py --dry-run "$PLAN_RAW" > "$WORK/deploy-raw.log" 2>&1); then
+  fail "deploy should have errored on raw targeting strings"
+  tail -20 "$WORK/deploy-raw.log"
+else
+  if grep -q "resolve.py" "$WORK/deploy-raw.log"; then
+    pass "deploy refused raw strings and pointed at resolve.py"
+  else
+    fail "deploy errored but message didn't mention resolve.py"
+    tail -20 "$WORK/deploy-raw.log"
+  fi
+fi
+
+deactivate
+
+# ---------------------------------------------------------------------------
 # Test 3 — motion render (ops-console example)
 # ---------------------------------------------------------------------------
 if [ $SKIP_MOTION -eq 1 ]; then


### PR DESCRIPTION
## Summary
- Write targeting in plain language; `resolve.py` turns strings into `{id, name, audience_size}` objects before deploy. Five fields: `interests`, `work_positions`, `work_employers`, `industries`, `behaviors`.
- Single `advantage_audience: bool` flag picks between Meta AI-expanded (default) and hard targeting — translates to `targeting_automation.advantage_audience: 0/1`.
- `deploy.py` builds `flexible_spec` from resolved entries and refuses raw strings with a pointer at `resolve.py`. Re-running resolve is idempotent.
- API version bump v21.0 → v22.0 (v21 was cut 2025-09-09).

## Workflow
```bash
# interactive top-3 picker
python3 adapters/meta/resolve.py plan.json

# non-interactive; dominant match only, fail on ambiguity
python3 adapters/meta/resolve.py --auto plan.json

# preview then deploy
python3 adapters/meta/deploy.py --dry-run plan.json
python3 adapters/meta/deploy.py plan.json
```

## Notes
- Silent `targetingoptionstatus` filter drops Meta's deprecating IDs without user-facing noise.
- Plan file is the cache — resolved entries skip re-resolution, so re-runs are free.
- Ambiguous case (plan has both `interests` and raw strings elsewhere) errors out with the exact adset + field so the user can see where resolve was missed.

## Test plan
- [x] `bash test/run-tests.sh --skip-motion` — 20/20 passing
- [x] `walk_targeting` resolves + is idempotent on re-run
- [x] `build_flexible_spec` + `apply_advantage_audience` unit coverage
- [x] deploy rejects raw strings with "run resolve.py first" message