### PR TITLE
chore: README hero + layout-synth RGB-canvas hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/social-preview.png" alt="adforge — brief to live ad" width="640">
+</p>
+
 # adforge
 
 > Brief-to-live-ad pipeline for Meta. Runs inside your agent (Claude Code, Codex, Cursor).

--- a/templates/.claude/skills/layout-synth/SKILL.md
+++ b/templates/.claude/skills/layout-synth/SKILL.md
@@ -53,6 +53,15 @@ Rules — non-negotiable:
 - **Size maps per format**: font sizes and offsets vary by aspect. Follow the `{"4x5": ..., "1x1": ..., "9x16": ...}` dict pattern from existing layouts.
 - **Respect `band_h`**: if `band_h > 0`, the top of the canvas is already occupied by a hero photo (set by `hero_mode: "top_band"`). Start layout content below it.
 - **Layout modules are PIL-only.** The module itself should import only `PIL` + `shared`. Keep it portable.
+- **Canvas is RGB, not RGBA.** Don't call `canvas.alpha_composite(...)` — it errors with `image has wrong mode`. For soft shadows / translucent overlays, build a grayscale `L` mask, blur it, then `canvas.paste(color_layer, (x, y), mask)`. Example shadow:
+  ```python
+  from PIL import Image, ImageDraw, ImageFilter
+  shadow_mask = Image.new("L", (w + 60, h + 60), 0)
+  ImageDraw.Draw(shadow_mask).rounded_rectangle([(30, 30), (w + 30, h + 30)], radius=48, fill=90)
+  shadow_mask = shadow_mask.filter(ImageFilter.GaussianBlur(20))
+  shadow_layer = Image.new("RGB", (w + 60, h + 60), (0, 0, 0))
+  canvas.paste(shadow_layer, (x - 30, y - 20), shadow_mask)
+  ```
 - **Asset preprocessing is open.** If the reference needs a cutout portrait, a duotoned product shot, a generated illustration, a masked photo, etc. — do that **outside the layout** as a prep step (ad-hoc venv, rembg, Flux, Photoshop, whatever works). The layout consumes the finished PNG. Don't bake one-off capabilities into adforge core; leave the creative problem-solving open.
 
 Module shape:

--- a/templates/engines/static/layouts/stat_card.py
+++ b/templates/engines/static/layouts/stat_card.py
@@ -47,7 +47,11 @@ def render(canvas, variant, brand, size, band_h):
     number = variant.get("number", variant.get("headline", "42"))
     nbbox = draw.textbbox((0, 0), number, font=number_font)
     draw.text((pad_x, cursor_y), number, font=number_font, fill=brand.accent)
-    cursor_y += (nbbox[3] - nbbox[1]) + 40
+    # bbox[3] is the ink's bottom in anchor-space, so the visual bottom of
+    # the number sits at cursor_y + nbbox[3]. Using the bbox height
+    # (nbbox[3] - nbbox[1]) drops nbbox[1] — the top gap serif fonts
+    # reserve above ink — and lets the label overlap into the number.
+    cursor_y += nbbox[3] + 40
 
     label = variant.get("label", variant.get("body", ""))
     for line in wrap_text(draw, label, label_font, content_w):


### PR DESCRIPTION
- Surface `assets/social-preview.png` at the top of the README.
- layout-synth: document that the compose canvas is RGB. New layouts must use `paste()` with an L-mask for shadows/overlays; `alpha_composite` errors with "image has wrong mode". Hit while writing a new tweet-screenshot layout in the flitz.io test run.