### PR TITLE
image gen: provider dispatcher + BFL as first built-in

### DIFF
--- a/templates/engines/static/flux.sh
+++ b/templates/engines/static/flux.sh
@@ -1,55 +1,23 @@
 #!/usr/bin/env bash
-# Hero image generator via Black Forest Labs Flux API.
+# Backcompat wrapper around generate_hero.py.
 #
-# Usage:
+# Historical signature kept for variants / skills that call flux.sh directly:
 #   ./engines/static/flux.sh <output_path> <width> <height> [model] <<<"$PROMPT"
-# Example:
-#   BFL_API_KEY=... ./engines/static/flux.sh assets/heroes/office.png 1024 1024 <<<"a warm editorial office photo"
 #
-# Env: BFL_API_KEY must be set.
+# New code should call generate_hero.py. flux.sh just forwards the request with
+# IMAGE_PROVIDER=bfl pinned, so nothing downstream of BFL-specific callers breaks.
 
 set -euo pipefail
 
 OUT="${1:?output path required}"
 WIDTH="${2:-1024}"
 HEIGHT="${3:-1024}"
-MODEL="${4:-flux-2-max}"
-PROMPT="$(cat)"
+MODEL_ARG="${4:-}"
 
-: "${BFL_API_KEY:?BFL_API_KEY not set}"
+if [[ -n "$MODEL_ARG" ]]; then
+  export BFL_MODEL="$MODEL_ARG"
+fi
 
-mkdir -p "$(dirname "$OUT")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "[flux] submitting $(basename "$OUT") (${WIDTH}x${HEIGHT}, $MODEL)"
-
-payload="$(PROMPT="$PROMPT" WIDTH="$WIDTH" HEIGHT="$HEIGHT" python3 -c 'import json,os; print(json.dumps({"prompt": os.environ["PROMPT"], "width": int(os.environ["WIDTH"]), "height": int(os.environ["HEIGHT"])}))')"
-
-submit_resp="$(curl -sS -X POST "https://api.bfl.ai/v1/$MODEL" \
-  -H "Content-Type: application/json" \
-  -H "x-key: $BFL_API_KEY" \
-  -d "$payload")"
-
-id="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["id"])' <<<"$submit_resp")"
-polling_url="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["polling_url"])' <<<"$submit_resp")"
-
-echo "[flux] id=$id"
-
-for i in $(seq 1 60); do
-  sleep 2
-  poll="$(curl -sS "$polling_url" -H "x-key: $BFL_API_KEY")"
-  status="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read()).get("status",""))' <<<"$poll")"
-  if [[ "$status" == "Ready" ]]; then
-    sample_url="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["result"]["sample"])' <<<"$poll")"
-    curl -sS "$sample_url" -o "$OUT"
-    echo "[flux] saved $OUT"
-    exit 0
-  fi
-  if [[ "$status" == "Error" || "$status" == "Failed" || "$status" == "Request Moderated" || "$status" == "Content Moderated" ]]; then
-    echo "[flux] failed ($status): $poll"
-    exit 1
-  fi
-  echo "[flux] status=$status (attempt $i)"
-done
-
-echo "[flux] timeout waiting for $id"
-exit 1
+IMAGE_PROVIDER=bfl exec python3 "$SCRIPT_DIR/generate_hero.py" "$OUT" "$WIDTH" "$HEIGHT"

--- a/templates/engines/static/generate_hero.py
+++ b/templates/engines/static/generate_hero.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Image-generation dispatcher.
+
+Usage (shell):
+    python3 engines/static/generate_hero.py <output_path> <width> <height> <<<"prompt text"
+
+Provider selection:
+    1. If IMAGE_PROVIDER is set, use that.
+    2. Otherwise, auto-detect from the first present API key in this order:
+       BFL_API_KEY, GEMINI_API_KEY (or GOOGLE_AI_STUDIO_API_KEY),
+       OPENAI_API_KEY, REPLICATE_API_TOKEN, STABILITY_API_KEY, FAL_KEY.
+    3. If nothing matches, exit with a clear hint about IMAGE_PROVIDER and the
+       hero_mode: "flat_brand_color" fallback.
+
+Provider modules live under engines/static/image_providers/. See CONTRACT.md
+there for the interface. Drop a new <name>.py to add a provider; the dispatcher
+picks it up automatically via IMAGE_PROVIDER=<name>.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+PROVIDERS_DIR = Path(__file__).parent / "image_providers"
+
+# Auto-detect order. First match wins. Keep in sync with CONTRACT.md + README.
+DETECTION_ORDER = [
+    ("bfl",       ["BFL_API_KEY"]),
+    ("google",    ["GEMINI_API_KEY", "GOOGLE_AI_STUDIO_API_KEY"]),
+    ("openai",    ["OPENAI_API_KEY"]),
+    ("replicate", ["REPLICATE_API_TOKEN"]),
+    ("stability", ["STABILITY_API_KEY"]),
+    ("fal",       ["FAL_KEY"]),
+]
+
+
+def _eprint(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def list_providers() -> list[str]:
+    """Return every provider module name found on disk (built-in + user-dropped)."""
+    if not PROVIDERS_DIR.is_dir():
+        return []
+    return sorted(
+        p.stem for p in PROVIDERS_DIR.glob("*.py")
+        if p.stem != "__init__" and not p.stem.startswith("_")
+    )
+
+
+def pick_provider() -> str:
+    """Resolve which provider to use. Raises RuntimeError if none."""
+    explicit = os.environ.get("IMAGE_PROVIDER", "").strip()
+    available = list_providers()
+
+    if explicit:
+        if explicit not in available:
+            raise RuntimeError(
+                f"IMAGE_PROVIDER={explicit!r} is set but no module "
+                f"engines/static/image_providers/{explicit}.py was found. "
+                f"Available: {', '.join(available) or '(none)'}."
+            )
+        return explicit
+
+    for name, keys in DETECTION_ORDER:
+        if name not in available:
+            continue
+        if any(os.environ.get(k) for k in keys):
+            return name
+
+    raise RuntimeError(
+        "No image provider could be auto-detected.\n"
+        "Either set IMAGE_PROVIDER=<name> and the matching API key, or set one of:\n"
+        "  BFL_API_KEY, GEMINI_API_KEY, OPENAI_API_KEY, REPLICATE_API_TOKEN, "
+        "STABILITY_API_KEY, FAL_KEY.\n"
+        "Without any key you can still render creatives — use "
+        "hero_mode: \"flat_brand_color\" in your variant."
+    )
+
+
+def load_provider(name: str):
+    """Import the provider module from disk. Works for built-in and user-dropped adapters."""
+    module_path = PROVIDERS_DIR / f"{name}.py"
+    if not module_path.is_file():
+        raise RuntimeError(f"Provider module not found: {module_path}")
+
+    spec = importlib.util.spec_from_file_location(
+        f"adforge_image_providers.{name}", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Failed to build import spec for {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    if not hasattr(module, "generate"):
+        raise RuntimeError(
+            f"Provider {name!r} does not define generate(prompt, width, height). "
+            f"See engines/static/image_providers/CONTRACT.md."
+        )
+    return module
+
+
+def generate_hero(prompt: str, width: int, height: int, provider: str | None = None) -> bytes:
+    """Programmatic entry point — pick a provider and return image bytes."""
+    name = provider or pick_provider()
+    module = load_provider(name)
+    return module.generate(prompt, width, height)
+
+
+def main() -> int:
+    if len(sys.argv) < 4:
+        _eprint("usage: generate_hero.py <output_path> <width> <height> <<<PROMPT")
+        return 2
+
+    output_path = Path(sys.argv[1])
+    try:
+        width = int(sys.argv[2])
+        height = int(sys.argv[3])
+    except ValueError:
+        _eprint("width and height must be integers")
+        return 2
+
+    prompt = sys.stdin.read().strip()
+    if not prompt:
+        _eprint("prompt is empty (read from stdin)")
+        return 2
+
+    try:
+        name = pick_provider()
+    except RuntimeError as e:
+        _eprint(f"[generate_hero] {e}")
+        return 1
+
+    _eprint(f"[generate_hero] provider={name} size={width}x{height} out={output_path}")
+
+    try:
+        image_bytes = generate_hero(prompt, width, height, provider=name)
+    except RuntimeError as e:
+        _eprint(f"[generate_hero] provider {name!r} failed: {e}")
+        return 1
+    except Exception as e:  # noqa: BLE001 — surface anything providers leak
+        _eprint(f"[generate_hero] unexpected error from {name!r}: {e}")
+        return 1
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(image_bytes)
+    _eprint(f"[generate_hero] saved {output_path} ({len(image_bytes)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/templates/engines/static/image_providers/CONTRACT.md
+++ b/templates/engines/static/image_providers/CONTRACT.md
@@ -1,0 +1,62 @@
+# Image provider contract
+
+Every module in this directory is an image-generation provider. The dispatcher (`../generate_hero.py`) loads them by name and calls a single function. Add a new provider by dropping a new `.py` file here that satisfies the contract below.
+
+## The function
+
+```python
+def generate(prompt: str, width: int, height: int) -> bytes:
+    ...
+```
+
+- Returns the raw PNG (or JPEG) bytes. The dispatcher writes them to the output path.
+- Takes exactly three arguments. No keyword-only args, no config dicts. Keep the surface boring.
+- If the provider's API doesn't support arbitrary widths/heights, pick the closest supported aspect / resolution and return that. Don't error out on non-standard sizes unless the provider literally refuses.
+- Raise `RuntimeError` with a human-readable message on any failure (missing key, bad response, moderation block, quota exhausted). The dispatcher catches and surfaces these.
+
+## Environment
+
+- Read the API key from an env var named `<PROVIDER>_API_KEY` (or the provider's canonical env var if different — e.g. `REPLICATE_API_TOKEN` is standard). Document which env var you use at the top of the module.
+- Support a `<PROVIDER>_MODEL` env var that overrides the module's default model.
+- No other env vars. Users shouldn't need a tutorial per provider.
+
+## Defaults
+
+- Pick a sensible default model — the one the provider themselves recommend, not the cheapest or the flagship. Users can override via env.
+- Prefer native PNG/JPEG output. If the API returns base64 or URL, decode/download inside the module and return bytes.
+
+## Sources of truth — non-negotiable
+
+When writing a new provider module, build **only** from:
+
+- The provider's official developer documentation (e.g. `platform.openai.com/docs`, `ai.google.dev/gemini-api/docs`, `replicate.com/docs`).
+- The provider's official GitHub repos, SDKs, or OpenAPI specs.
+- Their official changelog / model cards.
+
+**Never** guess endpoint paths, header names, request shapes, or response fields from training-data recall. Never base an adapter on Stack Overflow, Medium articles, or random blog posts. If the docs are ambiguous, send one live request with a throwaway key, observe the shape, and cite what you observed.
+
+At the top of each module, comment the primary docs URL(s) and the date you verified them against:
+
+```python
+# OpenAI Images API — https://platform.openai.com/docs/api-reference/images/create
+# Verified: 2026-04-21
+```
+
+## Two reference implementations
+
+The built-in modules are the canonical examples. Read them before writing a new one:
+
+- **`bfl.py`** — async submit-then-poll pattern. BFL returns a job ID and a polling URL; the adapter loops until the job is `Ready`, then downloads the resulting image from the returned URL. Use this shape for any provider that queues work rather than blocking.
+- **`openai.py`** — sync request/response pattern. Returns base64 inline in the response body. Use this shape for providers that block until the image is ready.
+
+Providers that return a URL instead of bytes: follow `bfl.py`'s `urllib.request.urlopen` pattern for the download step.
+
+## Keep it stdlib
+
+All built-in adapters use only the Python standard library (`urllib.request`, `json`, `base64`, `os`, `time`). Pillow is available. Nothing else. If your adapter *really* needs a vendor SDK, justify it in a comment — added deps land in `requirements.txt`.
+
+## Testing your new provider
+
+1. `IMAGE_PROVIDER=<name> python3 engines/static/generate_hero.py /tmp/test.png 1024 1024 <<<"a simple test prompt"` — should produce a valid PNG.
+2. Run `./test/run-tests.sh --skip-motion` — the dispatcher's shape-test suite catches common mistakes (wrong endpoint, missing auth header).
+3. Open the resulting image. If it renders, your adapter works end-to-end.

--- a/templates/engines/static/image_providers/__init__.py
+++ b/templates/engines/static/image_providers/__init__.py
@@ -1,0 +1,1 @@
+"""Image-generation provider adapters. See CONTRACT.md."""

--- a/templates/engines/static/image_providers/bfl.py
+++ b/templates/engines/static/image_providers/bfl.py
@@ -1,0 +1,103 @@
+"""
+Black Forest Labs (FLUX) image provider.
+
+Docs: https://docs.bfl.ai/api-reference (async submit-then-poll pattern)
+Verified: 2026-04-21
+
+Env:
+    BFL_API_KEY   required — https://dashboard.bfl.ai/keys
+    BFL_MODEL     optional — defaults to flux-2-max. Other options:
+                  flux-2-pro, flux-2-flex, flux-pro-1.1, flux-schnell, …
+
+The BFL API is asynchronous: POST /v1/<model> returns {id, polling_url},
+then GET polling_url loops until status is "Ready" and result.sample holds
+the image URL.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+DEFAULT_MODEL = "flux-2-max"
+ENDPOINT = "https://api.bfl.ai/v1"
+POLL_MAX_ATTEMPTS = 60
+POLL_INTERVAL_SECONDS = 2
+
+
+def _api_key() -> str:
+    key = os.environ.get("BFL_API_KEY", "").strip()
+    if not key:
+        raise RuntimeError("BFL_API_KEY is not set")
+    return key
+
+
+def _model() -> str:
+    return os.environ.get("BFL_MODEL", "").strip() or DEFAULT_MODEL
+
+
+def _post_json(url: str, body: dict, headers: dict) -> dict:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method="POST")
+    req.add_header("Content-Type", "application/json")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"BFL submit failed: HTTP {e.code} — {detail}") from e
+
+
+def _get_json(url: str, headers: dict) -> dict:
+    req = urllib.request.Request(url, method="GET")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"BFL poll failed: HTTP {e.code} — {detail}") from e
+
+
+def _download(url: str) -> bytes:
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"BFL image download failed: HTTP {e.code}") from e
+
+
+def generate(prompt: str, width: int, height: int) -> bytes:
+    model = _model()
+    headers = {"x-key": _api_key()}
+    body = {"prompt": prompt, "width": int(width), "height": int(height)}
+
+    submit = _post_json(f"{ENDPOINT}/{model}", body, headers)
+    job_id = submit.get("id")
+    polling_url = submit.get("polling_url")
+    if not job_id or not polling_url:
+        raise RuntimeError(f"BFL submit response missing id/polling_url: {submit!r}")
+
+    for attempt in range(1, POLL_MAX_ATTEMPTS + 1):
+        time.sleep(POLL_INTERVAL_SECONDS)
+        poll = _get_json(polling_url, headers)
+        status = poll.get("status", "")
+        if status == "Ready":
+            sample_url = poll.get("result", {}).get("sample")
+            if not sample_url:
+                raise RuntimeError(f"BFL Ready status missing result.sample: {poll!r}")
+            return _download(sample_url)
+        if status in {"Error", "Failed", "Request Moderated", "Content Moderated"}:
+            raise RuntimeError(f"BFL job failed ({status}): {poll!r}")
+
+    raise RuntimeError(
+        f"BFL job {job_id} did not reach Ready after "
+        f"{POLL_MAX_ATTEMPTS * POLL_INTERVAL_SECONDS}s"
+    )

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -68,6 +68,10 @@ expected=(
   "engines/static/compose.py"
   "engines/static/shared.py"
   "engines/static/flux.sh"
+  "engines/static/generate_hero.py"
+  "engines/static/image_providers/CONTRACT.md"
+  "engines/static/image_providers/__init__.py"
+  "engines/static/image_providers/bfl.py"
   "engines/static/requirements.txt"
   "engines/static/examples/__init__.py"
   "engines/static/examples/advertorial.py"
@@ -560,6 +564,233 @@ then
 else
   fail "locale map"
   cat "$WORK/locale-map.log"
+fi
+
+deactivate
+
+# ---------------------------------------------------------------------------
+# Test 2f — image provider dispatcher (generate_hero.py + bfl.py)
+# ---------------------------------------------------------------------------
+head "Test 2f: image provider dispatcher"
+
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+
+# 2f.1 — list_providers must find the built-in bfl module on disk.
+if python3 - <<PY > "$WORK/dispatcher-list.log" 2>&1
+import sys
+sys.path.insert(0, "$PROJECT/engines/static")
+from generate_hero import list_providers
+providers = list_providers()
+assert "bfl" in providers, providers
+print("ok", providers)
+PY
+then
+  pass "list_providers finds bfl on disk"
+else
+  fail "list_providers"
+  cat "$WORK/dispatcher-list.log"
+fi
+
+# 2f.2 — pick_provider picks bfl when only BFL_API_KEY is set.
+if env -i PATH="$PATH" BFL_API_KEY=dummy python3 - <<PY > "$WORK/dispatcher-auto.log" 2>&1
+import sys
+sys.path.insert(0, "$PROJECT/engines/static")
+from generate_hero import pick_provider
+assert pick_provider() == "bfl"
+print("ok")
+PY
+then
+  pass "pick_provider auto-detects bfl from BFL_API_KEY"
+else
+  fail "auto-detect bfl"
+  cat "$WORK/dispatcher-auto.log"
+fi
+
+# 2f.3 — IMAGE_PROVIDER=bfl wins over missing keys (explicit override path).
+if env -i PATH="$PATH" IMAGE_PROVIDER=bfl python3 - <<PY > "$WORK/dispatcher-explicit.log" 2>&1
+import sys
+sys.path.insert(0, "$PROJECT/engines/static")
+from generate_hero import pick_provider
+assert pick_provider() == "bfl"
+print("ok")
+PY
+then
+  pass "IMAGE_PROVIDER override resolves without a key set"
+else
+  fail "explicit override"
+  cat "$WORK/dispatcher-explicit.log"
+fi
+
+# 2f.4 — IMAGE_PROVIDER=bogus errors with "Available:" listing built-ins.
+if env -i PATH="$PATH" IMAGE_PROVIDER=bogus python3 - <<PY > "$WORK/dispatcher-bogus.log" 2>&1
+import sys
+sys.path.insert(0, "$PROJECT/engines/static")
+from generate_hero import pick_provider
+try:
+    pick_provider()
+except RuntimeError as e:
+    msg = str(e)
+    assert "bogus" in msg, msg
+    assert "Available" in msg, msg
+    assert "bfl" in msg, msg
+    print("ok")
+else:
+    raise SystemExit("expected RuntimeError")
+PY
+then
+  pass "unknown IMAGE_PROVIDER errors with helpful hint"
+else
+  fail "bogus provider error"
+  cat "$WORK/dispatcher-bogus.log"
+fi
+
+# 2f.5 — no keys + no IMAGE_PROVIDER must fail with flat_brand_color hint.
+if env -i PATH="$PATH" python3 - <<PY > "$WORK/dispatcher-nokey.log" 2>&1
+import sys
+sys.path.insert(0, "$PROJECT/engines/static")
+from generate_hero import pick_provider
+try:
+    pick_provider()
+except RuntimeError as e:
+    msg = str(e)
+    assert "IMAGE_PROVIDER" in msg, msg
+    assert "flat_brand_color" in msg, msg
+    print("ok")
+else:
+    raise SystemExit("expected RuntimeError")
+PY
+then
+  pass "no-key path prints IMAGE_PROVIDER + flat_brand_color hint"
+else
+  fail "no-key error"
+  cat "$WORK/dispatcher-nokey.log"
+fi
+
+# 2f.6 — bfl module shape: correct endpoint, x-key header, body payload,
+# polls until Ready, downloads sample URL. Uses stubbed HTTP helpers so no
+# live BFL call is made.
+if env -i PATH="$PATH" BFL_API_KEY=test-key python3 - <<PY > "$WORK/dispatcher-bfl-shape.log" 2>&1
+import importlib.util, sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "bfl_under_test",
+    Path("$PROJECT/engines/static/image_providers/bfl.py"),
+)
+bfl = importlib.util.module_from_spec(spec); spec.loader.exec_module(bfl)
+
+seen = {"posts": [], "gets": [], "downloads": []}
+
+def fake_post(url, body, headers):
+    seen["posts"].append((url, body, headers))
+    return {"id": "job-123", "polling_url": "https://api.bfl.ai/v1/get_result?id=job-123"}
+
+def fake_get(url, headers):
+    seen["gets"].append((url, headers))
+    # second poll returns Ready
+    if len(seen["gets"]) == 1:
+        return {"status": "Pending"}
+    return {"status": "Ready", "result": {"sample": "https://cdn.bfl.ai/img.png"}}
+
+def fake_download(url):
+    seen["downloads"].append(url)
+    return b"\x89PNG\r\n\x1a\nfakebytes"
+
+bfl._post_json = fake_post
+bfl._get_json = fake_get
+bfl._download = fake_download
+bfl.POLL_INTERVAL_SECONDS = 0  # don't sleep in tests
+
+out = bfl.generate("a cat", 1024, 1024)
+assert out == b"\x89PNG\r\n\x1a\nfakebytes"
+
+# submit shape
+assert len(seen["posts"]) == 1
+url, body, headers = seen["posts"][0]
+assert url == "https://api.bfl.ai/v1/flux-2-max", url
+assert headers == {"x-key": "test-key"}, headers
+assert body == {"prompt": "a cat", "width": 1024, "height": 1024}, body
+
+# poll shape
+assert len(seen["gets"]) == 2
+for gurl, ghdr in seen["gets"]:
+    assert gurl == "https://api.bfl.ai/v1/get_result?id=job-123"
+    assert ghdr == {"x-key": "test-key"}
+
+# download
+assert seen["downloads"] == ["https://cdn.bfl.ai/img.png"]
+print("ok")
+PY
+then
+  pass "bfl module: endpoint, x-key header, poll loop, download"
+else
+  fail "bfl shape"
+  cat "$WORK/dispatcher-bfl-shape.log"
+fi
+
+# 2f.7 — BFL_MODEL override changes the submit URL.
+if env -i PATH="$PATH" BFL_API_KEY=test-key BFL_MODEL=flux-schnell python3 - <<PY > "$WORK/dispatcher-bfl-model.log" 2>&1
+import importlib.util
+from pathlib import Path
+spec = importlib.util.spec_from_file_location(
+    "bfl_under_test2",
+    Path("$PROJECT/engines/static/image_providers/bfl.py"),
+)
+bfl = importlib.util.module_from_spec(spec); spec.loader.exec_module(bfl)
+
+seen_url = []
+bfl._post_json = lambda url, body, headers: (seen_url.append(url) or
+    {"id": "j", "polling_url": "p"})
+bfl._get_json = lambda url, headers: {"status": "Ready", "result": {"sample": "s"}}
+bfl._download = lambda url: b"px"
+bfl.POLL_INTERVAL_SECONDS = 0
+
+bfl.generate("x", 512, 512)
+assert seen_url == ["https://api.bfl.ai/v1/flux-schnell"], seen_url
+print("ok")
+PY
+then
+  pass "BFL_MODEL env overrides the submit URL"
+else
+  fail "BFL_MODEL override"
+  cat "$WORK/dispatcher-bfl-model.log"
+fi
+
+# 2f.8 — flux.sh is still callable (backcompat wrapper). Feeds stdin prompt
+# and a non-existent output path through a dry wrapper: we don't want a real
+# BFL call, so we intercept by replacing generate_hero.py's generate call via
+# a temp PYTHONPATH that shadows the real bfl module.
+SHADOW="$WORK/shadow_providers"
+mkdir -p "$SHADOW/engines/static/image_providers"
+cat > "$SHADOW/engines/static/image_providers/bfl.py" <<'PY'
+def generate(prompt, width, height):
+    return b"\x89PNG\r\n\x1a\n" + f"{prompt}|{width}x{height}".encode()
+PY
+touch "$SHADOW/engines/static/image_providers/__init__.py"
+
+# Copy the real dispatcher into the shadow tree so it finds our fake bfl.py
+cp "$PROJECT/engines/static/generate_hero.py" "$SHADOW/engines/static/generate_hero.py"
+cp "$PROJECT/engines/static/flux.sh" "$SHADOW/engines/static/flux.sh"
+chmod +x "$SHADOW/engines/static/flux.sh" "$SHADOW/engines/static/generate_hero.py"
+
+SHADOW_OUT="$WORK/shadow_hero.png"
+if BFL_API_KEY=fake bash "$SHADOW/engines/static/flux.sh" "$SHADOW_OUT" 800 600 <<<"shadow test" > "$WORK/flux-wrapper.log" 2>&1; then
+  if [ -f "$SHADOW_OUT" ] && python3 -c "
+import sys
+data = open(sys.argv[1], 'rb').read()
+assert data.startswith(b'\x89PNG\r\n\x1a\n'), data[:8]
+assert b'shadow test|800x600' in data, data
+" "$SHADOW_OUT" > "$WORK/flux-wrapper-check.log" 2>&1; then
+    pass "flux.sh wrapper routes through dispatcher + writes output"
+  else
+    fail "flux.sh wrapper did not write a PNG-shaped file"
+    cat "$WORK/flux-wrapper.log"
+    cat "$WORK/flux-wrapper-check.log"
+  fi
+else
+  fail "flux.sh wrapper exit code"
+  cat "$WORK/flux-wrapper.log"
 fi
 
 deactivate


### PR DESCRIPTION
## Summary

PR 1 of 3 for the provider-neutral image pipeline (v0.3.0 track).

- `engines/static/generate_hero.py` — dispatcher. Picks a provider from `IMAGE_PROVIDER` or auto-detects from the first present API key (`BFL_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`, `REPLICATE_API_TOKEN`, `STABILITY_API_KEY`, `FAL_KEY`). Loads the matching `image_providers/<name>.py` via `importlib.util`, so adding a provider is a single-file drop.
- `engines/static/image_providers/bfl.py` — first built-in provider. Ports `flux.sh`'s async submit-then-poll flow. Default model `flux-2-max`, `BFL_MODEL` overrides.
- `engines/static/flux.sh` — stays as a thin backcompat wrapper that pins `IMAGE_PROVIDER=bfl` and forwards to `generate_hero.py`. Existing skills / variants calling `flux.sh` directly keep working.
- `engines/static/image_providers/CONTRACT.md` — provider interface, env-var convention (`<PROVIDER>_API_KEY` / `<PROVIDER>_MODEL`), stdlib-only rule, and the non-negotiable that new providers are built from official docs only.

## Test plan

- [x] `./test/run-tests.sh --skip-motion` — 29/29 pass
  - Test 2f covers dispatcher listing, auto-detect, `IMAGE_PROVIDER` override, bogus-name error, no-key error (points at `flat_brand_color` fallback), BFL endpoint + `x-key` header + body shape + poll loop + download (mocked HTTP, no live BFL call), `BFL_MODEL` override, and `flux.sh` wrapper end-to-end against a shadow provider tree.
- [x] Scaffold still produces all expected files (42 total, including the 4 new ones).

## What this does NOT do

- No new providers yet — PR 2 adds Google (Nano Banana), OpenAI, Replicate (nano-banana-2 as default), Stability, fal.
- No agent-synth path yet — PR 3 adds the `image-provider-synth` skill for unknown providers.
- No README / CHANGELOG / version bump — PR 3 ships those as one unit with `v0.3.0`.