### PR TITLE
image gen: add 5 built-in providers (google, openai, replicate, stability, fal)

### DIFF
--- a/templates/engines/static/image_providers/fal.py
+++ b/templates/engines/static/image_providers/fal.py
@@ -1,0 +1,110 @@
+"""
+fal.ai — queue API for image generation.
+
+Docs: https://docs.fal.ai/model-apis/model-endpoints/queue
+Verified: 2026-04-20
+
+Env:
+    FAL_KEY       required — https://fal.ai/dashboard/keys
+    FAL_MODEL     optional — defaults to fal-ai/flux/schnell (fast + cheap).
+
+fal is queue-based: POST returns request_id + status_url + response_url;
+poll status_url until status == "COMPLETED", then GET response_url for the
+payload and download the first image URL.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+DEFAULT_MODEL = "fal-ai/flux/schnell"
+ENDPOINT = "https://queue.fal.run"
+POLL_MAX_ATTEMPTS = 60
+POLL_INTERVAL_SECONDS = 2
+
+
+def _api_key() -> str:
+    key = os.environ.get("FAL_KEY", "").strip()
+    if not key:
+        raise RuntimeError("FAL_KEY is not set")
+    return key
+
+
+def _model() -> str:
+    return os.environ.get("FAL_MODEL", "").strip() or DEFAULT_MODEL
+
+
+def _headers() -> dict:
+    return {"Authorization": f"Key {_api_key()}"}
+
+
+def _post(url: str, body: dict) -> dict:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method="POST")
+    req.add_header("Content-Type", "application/json")
+    for k, v in _headers().items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"fal submit failed: HTTP {e.code} — {detail}") from e
+
+
+def _get(url: str) -> dict:
+    req = urllib.request.Request(url, method="GET")
+    for k, v in _headers().items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"fal poll failed: HTTP {e.code} — {detail}") from e
+
+
+def _download(url: str) -> bytes:
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"fal image download failed: HTTP {e.code}") from e
+
+
+def generate(prompt: str, width: int, height: int) -> bytes:
+    submit_url = f"{ENDPOINT}/{_model()}"
+    body = {
+        "prompt": prompt,
+        "image_size": {"width": int(width), "height": int(height)},
+    }
+    submit = _post(submit_url, body)
+    status_url = submit.get("status_url")
+    response_url = submit.get("response_url")
+    if not status_url or not response_url:
+        raise RuntimeError(f"fal submit response missing status_url/response_url: {submit!r}")
+
+    for _ in range(POLL_MAX_ATTEMPTS):
+        time.sleep(POLL_INTERVAL_SECONDS)
+        status = _get(status_url)
+        state = status.get("status", "")
+        if state == "COMPLETED":
+            break
+        if state not in {"IN_QUEUE", "IN_PROGRESS"}:
+            raise RuntimeError(f"fal unexpected status {state!r}: {status!r}")
+    else:
+        raise RuntimeError(
+            f"fal request {submit.get('request_id')!r} did not complete in "
+            f"{POLL_MAX_ATTEMPTS * POLL_INTERVAL_SECONDS}s"
+        )
+
+    result = _get(response_url)
+    images = result.get("images") or []
+    if not images or not images[0].get("url"):
+        raise RuntimeError(f"fal completed but response has no images[0].url: {result!r}")
+    return _download(images[0]["url"])

--- a/templates/engines/static/image_providers/google.py
+++ b/templates/engines/static/image_providers/google.py
@@ -1,0 +1,86 @@
+"""
+Google Gemini image generation — "Nano Banana" (gemini-2.5-flash-image).
+
+Docs: https://ai.google.dev/gemini-api/docs/image-generation
+Verified: 2026-04-20
+
+Env:
+    GEMINI_API_KEY              required — https://aistudio.google.com/apikey
+    GOOGLE_AI_STUDIO_API_KEY    accepted as alias
+    GEMINI_MODEL                optional — defaults to gemini-2.5-flash-image
+
+Gemini's image API is synchronous: POST generateContent with the prompt,
+responseModalities=["TEXT","IMAGE"] and an imageConfig.aspectRatio derived from
+the requested width/height. The response carries the PNG inline as base64 in
+candidates[0].content.parts[*].inlineData.data.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import math
+import os
+import urllib.error
+import urllib.request
+
+DEFAULT_MODEL = "gemini-2.5-flash-image"
+ENDPOINT = "https://generativelanguage.googleapis.com/v1beta/models"
+
+# Aspect ratios Gemini's imageConfig accepts (from the public docs).
+_SUPPORTED_ASPECTS = [
+    (1, 1), (1, 4), (1, 8), (2, 3), (3, 2), (3, 4), (4, 1),
+    (4, 3), (4, 5), (5, 4), (8, 1), (9, 16), (16, 9), (21, 9),
+]
+
+
+def _api_key() -> str:
+    key = (
+        os.environ.get("GEMINI_API_KEY", "").strip()
+        or os.environ.get("GOOGLE_AI_STUDIO_API_KEY", "").strip()
+    )
+    if not key:
+        raise RuntimeError(
+            "GEMINI_API_KEY is not set (GOOGLE_AI_STUDIO_API_KEY also accepted)"
+        )
+    return key
+
+
+def _model() -> str:
+    return os.environ.get("GEMINI_MODEL", "").strip() or DEFAULT_MODEL
+
+
+def _closest_aspect(width: int, height: int) -> str:
+    target = width / height
+    best = min(_SUPPORTED_ASPECTS, key=lambda ab: abs(math.log(ab[0] / ab[1]) - math.log(target)))
+    return f"{best[0]}:{best[1]}"
+
+
+def generate(prompt: str, width: int, height: int) -> bytes:
+    key = _api_key()
+    model = _model()
+    url = f"{ENDPOINT}/{model}:generateContent"
+    body = {
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {"responseModalities": ["TEXT", "IMAGE"]},
+        "imageConfig": {"aspectRatio": _closest_aspect(int(width), int(height))},
+    }
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("x-goog-api-key", key)
+
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Gemini generate failed: HTTP {e.code} — {detail}") from e
+
+    for cand in payload.get("candidates", []):
+        for part in cand.get("content", {}).get("parts", []):
+            inline = part.get("inlineData") or part.get("inline_data")
+            if inline and inline.get("data"):
+                return base64.b64decode(inline["data"])
+
+    raise RuntimeError(f"Gemini response had no inlineData image: {payload!r}")

--- a/templates/engines/static/image_providers/openai.py
+++ b/templates/engines/static/image_providers/openai.py
@@ -1,0 +1,70 @@
+"""
+OpenAI Images API — gpt-image-1.
+
+Docs: https://platform.openai.com/docs/api-reference/images/create
+      https://platform.openai.com/docs/guides/image-generation
+Verified: 2026-04-20
+
+Env:
+    OPENAI_API_KEY    required — https://platform.openai.com/api-keys
+    OPENAI_MODEL      optional — defaults to gpt-image-1. Also accepts
+                      gpt-image-1-mini / gpt-image-1.5.
+
+gpt-image-1 is synchronous and always returns base64 (the legacy
+response_format=url flag is not supported for GPT image models). Supported
+sizes: "auto", "1024x1024", "1536x1024" (landscape), "1024x1536" (portrait).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import urllib.error
+import urllib.request
+
+DEFAULT_MODEL = "gpt-image-1"
+ENDPOINT = "https://api.openai.com/v1/images/generations"
+_SUPPORTED_SIZES = [(1024, 1024), (1536, 1024), (1024, 1536)]
+
+
+def _api_key() -> str:
+    key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if not key:
+        raise RuntimeError("OPENAI_API_KEY is not set")
+    return key
+
+
+def _model() -> str:
+    return os.environ.get("OPENAI_MODEL", "").strip() or DEFAULT_MODEL
+
+
+def _closest_size(width: int, height: int) -> str:
+    target = width / height
+    best = min(_SUPPORTED_SIZES, key=lambda wh: abs(wh[0] / wh[1] - target))
+    return f"{best[0]}x{best[1]}"
+
+
+def generate(prompt: str, width: int, height: int) -> bytes:
+    body = {
+        "model": _model(),
+        "prompt": prompt,
+        "n": 1,
+        "size": _closest_size(int(width), int(height)),
+    }
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(ENDPOINT, data=data, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Authorization", f"Bearer {_api_key()}")
+
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"OpenAI image generation failed: HTTP {e.code} — {detail}") from e
+
+    items = payload.get("data", [])
+    if not items or not items[0].get("b64_json"):
+        raise RuntimeError(f"OpenAI response missing data[0].b64_json: {payload!r}")
+    return base64.b64decode(items[0]["b64_json"])

--- a/templates/engines/static/image_providers/replicate.py
+++ b/templates/engines/static/image_providers/replicate.py
@@ -1,0 +1,146 @@
+"""
+Replicate — unified gateway for image generation models.
+
+Docs: https://replicate.com/docs/reference/http
+Verified: 2026-04-20
+
+Env:
+    REPLICATE_API_TOKEN   required — https://replicate.com/account/api-tokens
+    REPLICATE_MODEL       optional — defaults to google/nano-banana-2
+                          (top trending model on Replicate as of 2026-04).
+
+Replicate speaks a queue-like API: POST /v1/models/<owner>/<name>/predictions
+returns a prediction with urls.get to poll. Passing `Prefer: wait=60` makes
+the initial POST block until the prediction finishes (or times out) so we
+mostly avoid polling for the default fast models.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+import urllib.error
+import urllib.request
+
+DEFAULT_MODEL = "google/nano-banana-2"
+ENDPOINT = "https://api.replicate.com/v1"
+POLL_MAX_ATTEMPTS = 60
+POLL_INTERVAL_SECONDS = 2
+
+_SUPPORTED_ASPECTS = [
+    (1, 1), (16, 9), (9, 16), (4, 3), (3, 4), (21, 9), (3, 2), (2, 3),
+    (4, 5), (5, 4),
+]
+
+
+def _api_token() -> str:
+    key = os.environ.get("REPLICATE_API_TOKEN", "").strip()
+    if not key:
+        raise RuntimeError("REPLICATE_API_TOKEN is not set")
+    return key
+
+
+def _model() -> str:
+    return os.environ.get("REPLICATE_MODEL", "").strip() or DEFAULT_MODEL
+
+
+def _closest_aspect(width: int, height: int) -> str:
+    target = width / height
+    best = min(_SUPPORTED_ASPECTS, key=lambda ab: abs(math.log(ab[0] / ab[1]) - math.log(target)))
+    return f"{best[0]}:{best[1]}"
+
+
+def _headers() -> dict:
+    return {
+        "Authorization": f"Bearer {_api_token()}",
+        "Content-Type": "application/json",
+    }
+
+
+def _post(url: str, body: dict, wait: bool) -> dict:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method="POST")
+    for k, v in _headers().items():
+        req.add_header(k, v)
+    if wait:
+        req.add_header("Prefer", "wait=60")
+    try:
+        with urllib.request.urlopen(req, timeout=90) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Replicate predict failed: HTTP {e.code} — {detail}") from e
+
+
+def _get(url: str) -> dict:
+    req = urllib.request.Request(url, method="GET")
+    req.add_header("Authorization", f"Bearer {_api_token()}")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Replicate poll failed: HTTP {e.code} — {detail}") from e
+
+
+def _download(url: str) -> bytes:
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"Replicate output download failed: HTTP {e.code}") from e
+
+
+def _extract_url(output) -> str | None:
+    """Replicate outputs vary by model: a string, a list of strings, or an
+    object with a 'url' field. Walk the common shapes."""
+    if isinstance(output, str):
+        return output
+    if isinstance(output, list) and output:
+        return _extract_url(output[0])
+    if isinstance(output, dict):
+        for key in ("url", "image", "image_url"):
+            if key in output:
+                return _extract_url(output[key])
+    return None
+
+
+def generate(prompt: str, width: int, height: int) -> bytes:
+    model = _model()
+    url = f"{ENDPOINT}/models/{model}/predictions"
+    body = {
+        "input": {
+            "prompt": prompt,
+            "aspect_ratio": _closest_aspect(int(width), int(height)),
+        }
+    }
+
+    pred = _post(url, body, wait=True)
+    status = pred.get("status", "")
+
+    if status not in {"succeeded", "failed", "canceled"}:
+        poll_url = pred.get("urls", {}).get("get")
+        if not poll_url:
+            raise RuntimeError(f"Replicate response missing urls.get: {pred!r}")
+        for _ in range(POLL_MAX_ATTEMPTS):
+            time.sleep(POLL_INTERVAL_SECONDS)
+            pred = _get(poll_url)
+            status = pred.get("status", "")
+            if status in {"succeeded", "failed", "canceled"}:
+                break
+        else:
+            raise RuntimeError(
+                f"Replicate prediction {pred.get('id')!r} did not finish in "
+                f"{POLL_MAX_ATTEMPTS * POLL_INTERVAL_SECONDS}s"
+            )
+
+    if status != "succeeded":
+        raise RuntimeError(f"Replicate prediction ended in status {status}: {pred!r}")
+
+    out_url = _extract_url(pred.get("output"))
+    if not out_url:
+        raise RuntimeError(f"Replicate succeeded but output missing a URL: {pred!r}")
+    return _download(out_url)

--- a/templates/engines/static/image_providers/stability.py
+++ b/templates/engines/static/image_providers/stability.py
@@ -1,0 +1,83 @@
+"""
+Stability AI — Stable Image Core (and siblings).
+
+Docs: https://platform.stability.ai/docs/api-reference
+Verified: 2026-04-20
+
+Env:
+    STABILITY_API_KEY   required — https://platform.stability.ai/account/keys
+    STABILITY_MODEL     optional — one of "core" (default), "ultra", "sd3".
+                        Maps to /v2beta/stable-image/generate/<model>.
+
+Stability expects multipart/form-data, even though there are no files in the
+request. Accept: image/* makes it stream raw PNG/JPEG bytes straight back, so
+no b64 decoding is needed.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import secrets
+import urllib.error
+import urllib.request
+
+DEFAULT_MODEL = "core"  # maps to .../generate/core
+ENDPOINT = "https://api.stability.ai/v2beta/stable-image/generate"
+
+_SUPPORTED_ASPECTS = [
+    (1, 1), (16, 9), (9, 16), (21, 9), (9, 21), (3, 2), (2, 3), (4, 5), (5, 4),
+]
+
+
+def _api_key() -> str:
+    key = os.environ.get("STABILITY_API_KEY", "").strip()
+    if not key:
+        raise RuntimeError("STABILITY_API_KEY is not set")
+    return key
+
+
+def _model() -> str:
+    return os.environ.get("STABILITY_MODEL", "").strip() or DEFAULT_MODEL
+
+
+def _closest_aspect(width: int, height: int) -> str:
+    target = width / height
+    best = min(_SUPPORTED_ASPECTS, key=lambda ab: abs(math.log(ab[0] / ab[1]) - math.log(target)))
+    return f"{best[0]}:{best[1]}"
+
+
+def _build_multipart(fields: dict) -> tuple[bytes, str]:
+    """Minimal multipart/form-data encoder (all fields are simple strings)."""
+    boundary = f"----adforge{secrets.token_hex(16)}"
+    lines: list[bytes] = []
+    for name, value in fields.items():
+        lines.append(f"--{boundary}".encode())
+        lines.append(f'Content-Disposition: form-data; name="{name}"'.encode())
+        lines.append(b"")
+        lines.append(str(value).encode("utf-8"))
+    lines.append(f"--{boundary}--".encode())
+    lines.append(b"")
+    body = b"\r\n".join(lines)
+    return body, boundary
+
+
+def generate(prompt: str, width: int, height: int) -> bytes:
+    url = f"{ENDPOINT}/{_model()}"
+    fields = {
+        "prompt": prompt,
+        "aspect_ratio": _closest_aspect(int(width), int(height)),
+        "output_format": "png",
+    }
+    body, boundary = _build_multipart(fields)
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Authorization", f"Bearer {_api_key()}")
+    req.add_header("Content-Type", f"multipart/form-data; boundary={boundary}")
+    req.add_header("Accept", "image/*")
+
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Stability generate failed: HTTP {e.code} — {detail}") from e

--- a/templates/env.example
+++ b/templates/env.example
@@ -1,6 +1,34 @@
-# Black Forest Labs (for hero image generation via flux)
-# https://dashboard.bfl.ai
+# Image generation — bring any one of these keys. adforge auto-detects in
+# this order: BFL, Google (Gemini/Nano Banana), OpenAI, Replicate, Stability,
+# fal. Or pin explicitly with IMAGE_PROVIDER=<name>.
+#
+# Without any key, variants can still render via hero_mode: "flat_brand_color".
+#IMAGE_PROVIDER=
+
+# Black Forest Labs (FLUX)  — https://dashboard.bfl.ai/keys
 BFL_API_KEY=
+#BFL_MODEL=flux-2-max
+
+# Google Gemini / Nano Banana  — https://aistudio.google.com/apikey
+GEMINI_API_KEY=
+#GEMINI_MODEL=gemini-2.5-flash-image
+
+# OpenAI Images (gpt-image-1)  — https://platform.openai.com/api-keys
+OPENAI_API_KEY=
+#OPENAI_MODEL=gpt-image-1
+
+# Replicate  — https://replicate.com/account/api-tokens
+# Free tier includes flux-schnell; default model is google/nano-banana-2.
+REPLICATE_API_TOKEN=
+#REPLICATE_MODEL=google/nano-banana-2
+
+# Stability AI (Stable Image Core/Ultra/SD3)  — https://platform.stability.ai/account/keys
+STABILITY_API_KEY=
+#STABILITY_MODEL=core
+
+# fal.ai  — https://fal.ai/dashboard/keys
+FAL_KEY=
+#FAL_MODEL=fal-ai/flux/schnell
 
 # Meta Marketing API (for deploy adapter)
 # https://developers.facebook.com/tools/explorer/

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -72,6 +72,11 @@ expected=(
   "engines/static/image_providers/CONTRACT.md"
   "engines/static/image_providers/__init__.py"
   "engines/static/image_providers/bfl.py"
+  "engines/static/image_providers/google.py"
+  "engines/static/image_providers/openai.py"
+  "engines/static/image_providers/replicate.py"
+  "engines/static/image_providers/stability.py"
+  "engines/static/image_providers/fal.py"
   "engines/static/requirements.txt"
   "engines/static/examples/__init__.py"
   "engines/static/examples/advertorial.py"
@@ -791,6 +796,281 @@ assert b'shadow test|800x600' in data, data
 else
   fail "flux.sh wrapper exit code"
   cat "$WORK/flux-wrapper.log"
+fi
+
+deactivate
+
+# ---------------------------------------------------------------------------
+# Test 2g — shape tests for the remaining 5 built-in providers
+# ---------------------------------------------------------------------------
+head "Test 2g: provider shape tests (google, openai, replicate, stability, fal)"
+
+# shellcheck disable=SC1091
+source "$VENV/bin/activate"
+
+# Shared helper: load a provider module from disk with arbitrary env.
+run_provider_test () {
+  local name="$1"      # label for failure messages
+  local log="$2"       # log file
+  local env_prefix="$3"  # env string like 'FOO=bar BAR=baz'
+  local mod_path="$4"
+  if eval "env -i PATH=\"\$PATH\" TEST_BODY=\"\$TEST_BODY\" $env_prefix python3 - \"$mod_path\" > \"$log\" 2>&1" <<'PY'
+import importlib.util, os, sys
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("mod_under_test", Path(sys.argv[1]))
+mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+exec(os.environ["TEST_BODY"], {"mod": mod})
+print("ok")
+PY
+  then
+    pass "$name"
+  else
+    fail "$name"
+    cat "$log"
+  fi
+}
+
+# 2g.1 — google (Nano Banana)
+GOOGLE_BODY='
+import json, base64
+calls = []
+class FakeResp:
+    def __init__(self, payload): self._p = json.dumps(payload).encode()
+    def read(self): return self._p
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+
+png = base64.b64encode(b"\x89PNG\r\n\x1a\nFAKEBYTES").decode()
+def fake_urlopen(req, timeout=None):
+    calls.append({"url": req.full_url, "headers": dict(req.header_items()), "body": req.data})
+    return FakeResp({"candidates": [{"content": {"parts": [
+        {"inlineData": {"mimeType": "image/png", "data": png}}
+    ]}}]})
+
+mod.urllib.request.urlopen = fake_urlopen
+out = mod.generate("a cat on a roof", 1024, 1024)
+assert out == b"\x89PNG\r\n\x1a\nFAKEBYTES", out
+c = calls[0]
+assert c["url"] == "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-image:generateContent", c["url"]
+hdrs = {k.lower(): v for k, v in c["headers"].items()}
+assert hdrs.get("x-goog-api-key") == "testkey", hdrs
+body = json.loads(c["body"])
+assert body["contents"][0]["parts"][0]["text"] == "a cat on a roof"
+assert body["generationConfig"]["responseModalities"] == ["TEXT", "IMAGE"]
+assert body["imageConfig"]["aspectRatio"] == "1:1", body["imageConfig"]
+'
+TEST_BODY="$GOOGLE_BODY" run_provider_test \
+  "google: endpoint + x-goog-api-key + body + b64 decode" \
+  "$WORK/dispatcher-google.log" \
+  "GEMINI_API_KEY=testkey" \
+  "$PROJECT/engines/static/image_providers/google.py"
+
+# 2g.2 — openai (gpt-image-1)
+OPENAI_BODY='
+import json, base64
+calls = []
+class FakeResp:
+    def __init__(self, payload): self._p = json.dumps(payload).encode()
+    def read(self): return self._p
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+
+png = base64.b64encode(b"\x89PNG\r\n\x1a\nOPENAIBYTES").decode()
+def fake_urlopen(req, timeout=None):
+    calls.append({"url": req.full_url, "headers": dict(req.header_items()), "body": req.data})
+    return FakeResp({"data": [{"b64_json": png}]})
+
+mod.urllib.request.urlopen = fake_urlopen
+out = mod.generate("a dog in the park", 1024, 1024)
+assert out == b"\x89PNG\r\n\x1a\nOPENAIBYTES", out
+c = calls[0]
+assert c["url"] == "https://api.openai.com/v1/images/generations", c["url"]
+hdrs = {k.lower(): v for k, v in c["headers"].items()}
+assert hdrs.get("authorization") == "Bearer testkey", hdrs
+body = json.loads(c["body"])
+assert body["model"] == "gpt-image-1", body
+assert body["prompt"] == "a dog in the park", body
+assert body["size"] == "1024x1024", body
+# landscape-leaning should pick 1536x1024
+out2 = mod.generate("x", 1920, 1080)
+body2 = json.loads(calls[1]["body"])
+assert body2["size"] == "1536x1024", body2["size"]
+'
+TEST_BODY="$OPENAI_BODY" run_provider_test \
+  "openai: endpoint + Bearer + gpt-image-1 body + size mapping" \
+  "$WORK/dispatcher-openai.log" \
+  "OPENAI_API_KEY=testkey" \
+  "$PROJECT/engines/static/image_providers/openai.py"
+
+# 2g.3 — replicate (google/nano-banana-2, Prefer: wait path, then fall-through poll)
+REPLICATE_BODY='
+import json
+class FakeResp:
+    def __init__(self, payload=None, bytes_=None):
+        self._p = bytes_ if bytes_ is not None else json.dumps(payload).encode()
+    def read(self): return self._p
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+
+# Case A: Prefer: wait returns already-succeeded
+seen = []
+def urlopen_a(req, timeout=None):
+    seen.append({"url": req.full_url, "headers": dict(req.header_items()), "body": req.data, "method": req.get_method()})
+    if req.get_method() == "POST":
+        return FakeResp({"id": "p1", "status": "succeeded",
+                          "output": ["https://cdn.replicate.com/out.png"]})
+    return FakeResp(bytes_=b"\x89PNG\r\n\x1a\nREPLIBYTES")
+
+mod.urllib.request.urlopen = urlopen_a
+mod.POLL_INTERVAL_SECONDS = 0
+out = mod.generate("a swan", 1600, 900)
+assert out == b"\x89PNG\r\n\x1a\nREPLIBYTES", out
+
+post = seen[0]
+assert post["url"] == "https://api.replicate.com/v1/models/google/nano-banana-2/predictions", post["url"]
+hdrs = {k.lower(): v for k, v in post["headers"].items()}
+assert hdrs.get("authorization") == "Bearer testkey", hdrs
+assert hdrs.get("prefer") == "wait=60", hdrs
+body = json.loads(post["body"])
+assert body["input"]["prompt"] == "a swan", body
+assert body["input"]["aspect_ratio"] == "16:9", body  # 1600x900 -> 16:9
+dl = seen[1]
+assert dl["url"] == "https://cdn.replicate.com/out.png", dl["url"]
+
+# Case B: POST returns starting, poll once to succeeded
+seen2 = []
+def urlopen_b(req, timeout=None):
+    seen2.append({"url": req.full_url, "method": req.get_method()})
+    if req.get_method() == "POST":
+        return FakeResp({"id": "p2", "status": "starting",
+                          "urls": {"get": "https://api.replicate.com/v1/predictions/p2"}})
+    if req.full_url == "https://api.replicate.com/v1/predictions/p2":
+        return FakeResp({"id": "p2", "status": "succeeded",
+                          "output": "https://cdn.replicate.com/out2.png"})
+    return FakeResp(bytes_=b"POLLPNG")
+
+mod.urllib.request.urlopen = urlopen_b
+out2 = mod.generate("test", 1024, 1024)
+assert out2 == b"POLLPNG", out2
+# Ensure we actually polled the urls.get endpoint before downloading
+assert any(s["url"] == "https://api.replicate.com/v1/predictions/p2" for s in seen2)
+'
+TEST_BODY="$REPLICATE_BODY" run_provider_test \
+  "replicate: nano-banana-2 endpoint + Bearer + Prefer wait + poll fallthrough + output url" \
+  "$WORK/dispatcher-replicate.log" \
+  "REPLICATE_API_TOKEN=testkey" \
+  "$PROJECT/engines/static/image_providers/replicate.py"
+
+# 2g.4 — stability (multipart, Accept: image/*, raw bytes)
+STABILITY_BODY='
+class FakeResp:
+    def __init__(self, b): self._b = b
+    def read(self): return self._b
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+
+seen = []
+def fake_urlopen(req, timeout=None):
+    seen.append({"url": req.full_url, "headers": dict(req.header_items()), "body": req.data})
+    return FakeResp(b"\x89PNG\r\n\x1a\nSTABILITYBYTES")
+
+mod.urllib.request.urlopen = fake_urlopen
+out = mod.generate("a forest", 1024, 1024)
+assert out == b"\x89PNG\r\n\x1a\nSTABILITYBYTES", out
+
+c = seen[0]
+assert c["url"] == "https://api.stability.ai/v2beta/stable-image/generate/core", c["url"]
+hdrs = {k.lower(): v for k, v in c["headers"].items()}
+assert hdrs.get("authorization") == "Bearer testkey", hdrs
+assert hdrs.get("accept") == "image/*", hdrs
+assert hdrs.get("content-type", "").startswith("multipart/form-data; boundary="), hdrs
+body = c["body"]
+# multipart must carry prompt, aspect_ratio, output_format
+assert b"name=\"prompt\"" in body, body
+assert b"a forest" in body, body
+assert b"name=\"aspect_ratio\"" in body, body
+assert b"1:1" in body, body
+assert b"name=\"output_format\"" in body, body
+assert b"png" in body, body
+
+# STABILITY_MODEL=ultra switches the URL path
+import os
+os.environ["STABILITY_MODEL"] = "ultra"
+mod.generate("x", 1024, 1024)
+assert seen[1]["url"] == "https://api.stability.ai/v2beta/stable-image/generate/ultra", seen[1]["url"]
+'
+TEST_BODY="$STABILITY_BODY" run_provider_test \
+  "stability: core endpoint + Bearer + Accept image/* + multipart fields + STABILITY_MODEL override" \
+  "$WORK/dispatcher-stability.log" \
+  "STABILITY_API_KEY=testkey" \
+  "$PROJECT/engines/static/image_providers/stability.py"
+
+# 2g.5 — fal (queue submit-poll-response)
+FAL_BODY='
+import json
+class FakeResp:
+    def __init__(self, payload=None, bytes_=None):
+        self._p = bytes_ if bytes_ is not None else json.dumps(payload).encode()
+    def read(self): return self._p
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+
+seen = []
+def fake_urlopen(req, timeout=None):
+    seen.append({"url": req.full_url, "headers": dict(req.header_items()),
+                  "body": req.data, "method": req.get_method()})
+    if req.get_method() == "POST":
+        return FakeResp({
+            "request_id": "r1",
+            "status_url": "https://queue.fal.run/fal-ai/flux/schnell/requests/r1/status",
+            "response_url": "https://queue.fal.run/fal-ai/flux/schnell/requests/r1",
+        })
+    if req.full_url.endswith("/status"):
+        # first poll IN_PROGRESS, next COMPLETED
+        poll_idx = sum(1 for s in seen if s["url"].endswith("/status")) - 1
+        return FakeResp({"status": "IN_PROGRESS"} if poll_idx == 0 else {"status": "COMPLETED"})
+    if req.full_url.endswith("/requests/r1"):
+        return FakeResp({"images": [{"url": "https://v3.fal.media/files/img.png"}]})
+    return FakeResp(bytes_=b"\x89PNG\r\n\x1a\nFALBYTES")
+
+mod.urllib.request.urlopen = fake_urlopen
+mod.POLL_INTERVAL_SECONDS = 0
+out = mod.generate("prompt text", 800, 1200)
+assert out == b"\x89PNG\r\n\x1a\nFALBYTES", out
+
+post = seen[0]
+assert post["url"] == "https://queue.fal.run/fal-ai/flux/schnell", post["url"]
+hdrs = {k.lower(): v for k, v in post["headers"].items()}
+assert hdrs.get("authorization") == "Key testkey", hdrs
+body = json.loads(post["body"])
+assert body["prompt"] == "prompt text", body
+assert body["image_size"] == {"width": 800, "height": 1200}, body
+
+# must have polled status and fetched response before downloading
+urls = [s["url"] for s in seen]
+assert any(u.endswith("/status") for u in urls)
+assert any(u.endswith("/requests/r1") for u in urls)
+assert "https://v3.fal.media/files/img.png" in urls
+'
+TEST_BODY="$FAL_BODY" run_provider_test \
+  "fal: queue submit + Key auth + image_size body + status poll + response url + download" \
+  "$WORK/dispatcher-fal.log" \
+  "FAL_KEY=testkey" \
+  "$PROJECT/engines/static/image_providers/fal.py"
+
+# 2g.6 — dispatcher auto-detection order: Google key wins over OpenAI key
+# (bfl still first; this checks that a missing-bfl env falls through properly)
+if env -i PATH="$PATH" GEMINI_API_KEY=g OPENAI_API_KEY=o python3 - <<PY > "$WORK/dispatcher-order.log" 2>&1
+import sys
+sys.path.insert(0, "$PROJECT/engines/static")
+from generate_hero import pick_provider
+assert pick_provider() == "google", pick_provider()
+PY
+then
+  pass "dispatcher auto-detects google before openai"
+else
+  fail "dispatcher order"
+  cat "$WORK/dispatcher-order.log"
 fi
 
 deactivate


### PR DESCRIPTION
## Summary

PR 2 of 5 for the provider-neutral image pipeline (v0.3.0 track). Adds the five long-promised provider modules alongside BFL:

| Provider   | Default model                | Style                            | Docs verified |
|------------|------------------------------|----------------------------------|---------------|
| google     | gemini-2.5-flash-image       | sync, inlineData base64          | 2026-04-20    |
| openai     | gpt-image-1                  | sync, data[0].b64_json           | 2026-04-20    |
| replicate  | google/nano-banana-2         | queue + Prefer: wait + poll      | 2026-04-20    |
| stability  | stable-image-core            | multipart + Accept: image/* raw  | 2026-04-20    |
| fal        | fal-ai/flux/schnell          | queue submit + status poll + response URL | 2026-04-20 |

All modules follow `image_providers/CONTRACT.md`:
- One function: `generate(prompt, width, height) -> bytes`.
- Env vars: `<PROVIDER>_API_KEY` + optional `<PROVIDER>_MODEL`.
- Stdlib only (`urllib.request`, `json`, `base64`). No SDK deps added.
- Width/height maps to the closest aspect each API supports.
- Source doc URL + verification date cited at the top of every module.

`env.example` now documents all six provider keys, `IMAGE_PROVIDER`, and per-provider model overrides. Keyless runs still fall back to `hero_mode: "flat_brand_color"`.

## Test plan

- [x] `./test/run-tests.sh --skip-motion` — **35/35 pass**
  - Test 2g mocks `urllib.request.urlopen` for each provider and asserts: endpoint URL, auth header (`x-goog-api-key` / `Authorization: Bearer` / `Authorization: Key`), request body shape (JSON or multipart), poll loop behavior (Replicate wait → poll fallthrough, fal `IN_PROGRESS` → `COMPLETED`), and model-env overrides (`STABILITY_MODEL=ultra` switches URL path).
  - Dispatcher auto-detection order checked: with both `GEMINI_API_KEY` and `OPENAI_API_KEY` set, `pick_provider()` returns `google` (correct — Google comes earlier in `DETECTION_ORDER`).

## What this does NOT do

- No agent-synth path yet — PR 3 adds `image-provider-synth` for unknown providers.
- No skill updates yet — PR 3 rewrites `setup` / `composer-speccer` / `new-campaign` to be provider-neutral.
- No README / CHANGELOG / version bump — PR 3.
- No `adforge upgrade` command — PR 4 (issue #15).
- No CI release via OIDC — PR 5 (issue #16); that PR will actually publish v0.3.0 to npm with provenance.