### PR TITLE
skills: provider-neutral setup/composer-speccer/new-campaign + image-provider-synth

### DIFF
--- a/templates/.claude/skills/composer-speccer/SKILL.md
+++ b/templates/.claude/skills/composer-speccer/SKILL.md
@@ -36,7 +36,7 @@ Brand wordmark placement isn't a variant field — it's configured once in `bran
 ## Defaults — follow unless user asks otherwise
 
 - **`formats`: `["4x5", "9x16"]`** — 4x5 goes to Feed (FB + IG), 9x16 goes to Stories (and Reels for motion). Never default to 1x1 (legacy placement, downranked). Never ship only one format "for later" — Meta's delivery rewards multi-placement from day one.
-- **`hero_mode`: `"flat_brand_color"`** — clean brand-color background, works without FLUX or stock images. Use `radiant_gradient` as an explicit stylistic choice; `background` or `top_band` if the user provides a photo; only use `background` with a FLUX-generated hero if `BFL_API_KEY` is set and the user asked for it.
+- **`hero_mode`: `"flat_brand_color"`** — clean brand-color background, works without any image-generation key. Use `radiant_gradient` as an explicit stylistic choice; `background` or `top_band` if the user provides a photo; only use `background` with a generated hero if an image-provider key is set (`BFL_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`, `REPLICATE_API_TOKEN`, `STABILITY_API_KEY`, or `FAL_KEY`) and the user asked for it.
 - **`cta`: omit or `""`** — Meta has a platform CTA button on every ad unit. An in-creative CTA text is redundant in most cases, and adds a second focal point that fights the platform button. Only include an in-creative `cta` if the user explicitly asks for one (e.g. stylistic "learn more" link under a pull-quote, or when the layout has no other bottom element).
 
 ## Process
@@ -49,6 +49,6 @@ Brand wordmark placement isn't a variant field — it's configured once in `bran
 
 ## Rules
 
-- Never invent hero images. If the brief implies a photo but none is specified: use `hero_mode: "flat_brand_color"` (new default), or if `BFL_API_KEY` is set and the user wants it, prompt-engineer a flux call and ask the user to run it.
+- Never invent hero images. If the brief implies a photo but none is specified: use `hero_mode: "flat_brand_color"` (default), or if an image-provider key is set and the user wants it, prompt-engineer a hero call — `engines/static/generate_hero.py` dispatches to whichever provider is configured.
 - Respect brand colors already in `brand.json` — don't override in variants unless the user explicitly asks.
 - Stat-card numbers must be sourced. No numbers without a `source` field.

--- a/templates/.claude/skills/image-provider-synth/SKILL.md
+++ b/templates/.claude/skills/image-provider-synth/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: image-provider-synth
+description: Backend skill — write a new image-generation provider adapter under engines/static/image_providers/ when the user brings a provider adforge doesn't have built-in. Use when the user has an API key for a provider other than BFL, Google, OpenAI, Replicate, Stability, or fal.
+---
+
+# image-provider-synth
+
+Generate a working `engines/static/image_providers/<name>.py` adapter for a provider adforge doesn't yet ship. The user tells you "I have a key for X" where X isn't one of the six built-ins — you write the adapter, the dispatcher picks it up automatically.
+
+This skill exists because adforge promises provider-neutrality, but no unified HTTP standard covers image-generation APIs. Each provider has its own shape. Instead of pretending to support a long-tail provider out of the box, we write the adapter on demand, from the provider's own docs.
+
+## When to invoke
+
+- The user says they have an API key for a provider whose name doesn't match any file in `engines/static/image_providers/`.
+- The user's existing stack uses a provider adforge doesn't ship (e.g. Mistral, Luma, Ideogram, Runway, Amazon Bedrock, Azure OpenAI, Together, Cloudflare Workers AI, a self-hosted Comfy/InvokeAI endpoint).
+- An ops user wants to wire a corporate inference gateway that mimics one of the supported APIs.
+
+If the provider is already in `engines/static/image_providers/` as a built-in (`bfl`, `google`, `openai`, `replicate`, `stability`, `fal`), do NOT synthesize — the user just needs to set the env var.
+
+## Non-negotiable: sources of truth
+
+Build the adapter **only** from:
+
+- The provider's official developer documentation (`<provider>.com/docs`, `docs.<provider>.*`, `api-docs.<provider>.*`, …).
+- The provider's official GitHub repos, SDKs, or OpenAPI specs.
+- Their official changelog / model cards.
+
+**Never** guess endpoint paths, header names, request shapes, or response fields from training-data recall. Never base an adapter on Stack Overflow, Medium articles, YouTube videos, or random blog posts. If the docs are ambiguous, send one live request with the user's throwaway key, observe the actual shape in the response, and cite what you observed.
+
+At the top of every adapter you write, include the primary docs URL(s) and today's date as the verification date. If a future reader doubts the adapter, they can re-verify against the same source.
+
+## Read the contract first
+
+`engines/static/image_providers/CONTRACT.md` is the spec. Every adapter in that dir must satisfy it:
+
+- One function: `generate(prompt: str, width: int, height: int) -> bytes`.
+- Env vars: `<PROVIDER>_API_KEY` (or the provider's canonical variable if different — `REPLICATE_API_TOKEN`, `FAL_KEY`), plus optional `<PROVIDER>_MODEL`.
+- Stdlib only (`urllib.request`, `json`, `base64`, `time`, `os`, `secrets`). Pillow is available. Nothing else unless the provider literally ships no REST surface.
+- Raise `RuntimeError` with a human-readable message on any failure (missing key, bad response, moderation block, quota exhausted).
+- Map the requested width/height to the closest aspect or size the provider supports. Don't error out on arbitrary sizes unless the provider literally refuses.
+
+## Read a reference adapter before writing
+
+Two shipped adapters cover the two common shapes. Read whichever matches before writing:
+
+- **Sync request/response** — `engines/static/image_providers/openai.py`. Block until the API returns a base64 payload or a URL.
+- **Queue + poll** — `engines/static/image_providers/bfl.py`. POST returns a job ID + polling URL; loop until status is terminal; download the final image.
+
+Providers that return a URL instead of bytes: follow the `_download(url)` pattern from `bfl.py` or `fal.py`.
+
+## Process
+
+### 1. Gather the primary docs
+
+Open the provider's docs page. Capture exactly, without paraphrasing:
+
+1. The full REST URL for the "generate image" endpoint.
+2. The authentication header format (`Authorization: Bearer $KEY`, `x-api-key`, `x-goog-api-key`, etc).
+3. The content-type — JSON body, multipart/form-data, or form-urlencoded.
+4. Every required request field.
+5. The response shape — where the image lives (raw bytes, `b64_json`, `inlineData.data`, a URL inside `output`, `images[0].url`).
+6. If asynchronous: how to poll (status values, polling URL shape) and where the image appears when done.
+7. The provider's default / recommended model and whether width/height are specified as pixels, aspect ratio, or a named preset.
+
+Paste the doc URL(s) and today's date into the top-of-file comment of the adapter you're about to write.
+
+### 2. Pick a file name
+
+`engines/static/image_providers/<name>.py`. Short, single-word, lowercase. Match the provider's canonical slug:
+
+- Mistral → `mistral.py`
+- Amazon Bedrock → `bedrock.py`
+- Azure OpenAI → `azure.py`
+- Cloudflare Workers AI → `cloudflare.py`
+- Self-hosted Comfy endpoint → ask the user what to call it (e.g. `comfy.py`, `local.py`)
+
+Don't collide with an existing file. `ls engines/static/image_providers/` before you write.
+
+### 3. Decide the env vars
+
+- `<PROVIDER>_API_KEY` is the default. If the provider's docs use a different canonical name (like `REPLICATE_API_TOKEN`), use theirs — users hate renaming standard env vars.
+- `<PROVIDER>_MODEL` is optional; users override the default model this way. Always support it.
+- Do not introduce any other env vars. No `<PROVIDER>_BASE_URL`, no `<PROVIDER>_REGION`, no `<PROVIDER>_ORG` unless the provider's API literally cannot function without it. Setup should not be a tutorial per provider.
+
+### 4. Draft the adapter
+
+Skeleton for a sync provider:
+
+```python
+"""
+<Provider> image generation.
+
+Docs: <official docs URL>
+Verified: <today's date>
+
+Env:
+    <PROVIDER>_API_KEY   required — <where to get it>
+    <PROVIDER>_MODEL     optional — defaults to <model>
+
+<one-line description of the request/response style>
+"""
+
+from __future__ import annotations
+
+import base64  # only if response is b64
+import json
+import os
+import urllib.error
+import urllib.request
+
+DEFAULT_MODEL = "<sensible default>"
+ENDPOINT = "<full URL>"
+
+
+def _api_key() -> str:
+    key = os.environ.get("<PROVIDER>_API_KEY", "").strip()
+    if not key:
+        raise RuntimeError("<PROVIDER>_API_KEY is not set")
+    return key
+
+
+def _model() -> str:
+    return os.environ.get("<PROVIDER>_MODEL", "").strip() or DEFAULT_MODEL
+
+
+def generate(prompt: str, width: int, height: int) -> bytes:
+    body = {...}  # per docs
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(ENDPOINT, data=data, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Authorization", f"Bearer {_api_key()}")
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"<Provider> generate failed: HTTP {e.code} — {detail}") from e
+    # Extract image bytes per response shape
+    ...
+    return image_bytes
+```
+
+Skeleton for a queue provider: see `bfl.py` or `fal.py` — mirror the submit → poll → download shape.
+
+### 5. Map width/height
+
+Every provider accepts size differently:
+
+- **Discrete sizes** (OpenAI: 1024x1024, 1536x1024, 1024x1536) — pick the closest by target aspect ratio.
+- **Aspect strings** (Gemini, Replicate, Stability: `1:1`, `16:9`, …) — pick the closest by log-ratio. See `google.py::_closest_aspect` for the pattern.
+- **Raw pixels** (BFL, fal) — pass width and height through as-is.
+- **Named presets** (some providers: `square`, `landscape`) — map to the preset closest to the target aspect.
+
+Don't error out on non-standard sizes. Just pick the closest supported value.
+
+### 6. Test end-to-end before declaring done
+
+1. Ask the user to drop their key into `.env`.
+2. Run the adapter via the dispatcher:
+   ```
+   IMAGE_PROVIDER=<name> python3 engines/static/generate_hero.py /tmp/test.png 1024 1024 <<<"a simple test prompt"
+   ```
+3. Open the file. Check it's a valid PNG/JPEG and the content roughly matches the prompt.
+4. Run `./test/run-tests.sh --skip-motion`. The dispatcher's shape-test suite catches wrong endpoint, missing auth, bad body shape.
+
+If any of these fail, fix the adapter — don't ship broken. Re-verify against the docs, and if they're ambiguous, do a curl by hand to see the actual response shape before editing.
+
+### 7. Optional: add a shape test
+
+If the adapter is likely to be shared back to adforge upstream, write a mock-HTTP shape test mirroring Test 2g in `test/run-tests.sh`. Stub `urllib.request.urlopen`, assert endpoint + headers + body shape + response parsing. The existing tests are the template — copy the pattern for your provider.
+
+## Rules
+
+- **Docs first.** If you can't find the endpoint in official docs in 5 minutes, ask the user for the doc URL. Don't invent it.
+- **No SDK dependencies.** The whole point of stdlib-only is that `npx adforge init` runs everywhere. If a provider's API is genuinely unreachable without an SDK, flag it to the user — don't silently add a dependency.
+- **Don't modify other adapters** to "normalize" them with the new one. Each adapter is self-contained.
+- **Don't touch the dispatcher** unless adding auto-detection for the new provider is warranted. Auto-detection in `generate_hero.py::DETECTION_ORDER` should only include providers adforge ships by default; user-synthesized adapters work via `IMAGE_PROVIDER=<name>`.
+- **Cite and date.** Every adapter's top-of-file comment carries the docs URL and the verification date. Future-you will thank present-you when an endpoint changes.

--- a/templates/.claude/skills/new-campaign/SKILL.md
+++ b/templates/.claude/skills/new-campaign/SKILL.md
@@ -12,7 +12,7 @@ Walk the user from a fresh idea to a PAUSED campaign on Meta.
 Before you interview, before you draft angles, check `.env`:
 
 - No `.env` at all → route to `setup` skill, don't proceed.
-- No `BFL_API_KEY` → hero generation will fall back to `flat_brand_color`. Warn the user before briefing ("creatives will use flat brand-color backgrounds, not AI-generated heroes — set BFL_API_KEY in .env if you want FLUX heroes — or another image source; adforge doesn't care where the PNG comes from"). Let them decide: proceed without, or pause to add the key.
+- No image-provider key (`BFL_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY`, `REPLICATE_API_TOKEN`, `STABILITY_API_KEY`, or `FAL_KEY`) → hero generation will fall back to `flat_brand_color`. Warn the user before briefing ("creatives will use flat brand-color backgrounds, not AI-generated heroes — set any one of the image-provider keys in .env if you want generated heroes; adforge auto-detects the one you provide, or use `IMAGE_PROVIDER=<name>` to pin it. Bringing a provider adforge doesn't have built-in? Invoke `image-provider-synth`."). Let them decide: proceed without, or pause to add a key.
 - No `META_ACCESS_TOKEN` → everything renders locally, but `deploy.py` will only run `--dry-run`. Tell the user they'll need to upload manually or set the token before the deploy stage.
 
 Skipping this check is how you end up generating twelve assets with wrong defaults that have to be thrown away.

--- a/templates/.claude/skills/setup/SKILL.md
+++ b/templates/.claude/skills/setup/SKILL.md
@@ -5,7 +5,7 @@ description: First-time onboarding — API keys, brand tokens, font files, dry-r
 
 # setup
 
-Onboard a new user. Keys first (so FLUX and Meta work downstream), then brand and fonts, then a dry-run to prove the pipeline renders.
+Onboard a new user. Keys first (so image generation and Meta work downstream), then brand and fonts, then a dry-run to prove the pipeline renders.
 
 ## 1. Check runtime
 
@@ -17,11 +17,24 @@ If `.env` is missing but `.env.example` exists, copy it: `cp .env.example .env`.
 
 For every key, if the user asks "was ist das" or "where do I get that", walk them through the exact click-path below. Do not skim.
 
-### `BFL_API_KEY` (optional — unlocks FLUX hero images)
+### Image-generation key (optional — any one of these unlocks AI hero images)
 
-- What it is: Black Forest Labs API key. Without it, creatives render with flat brand-color backgrounds instead of generated hero images.
-- Where to get it: https://dashboard.bfl.ai → sign up → API Keys → Create Key. Pay-as-you-go, ~1ct per image.
-- If skipped: creatives still render, just with `hero_mode: "flat_brand_color"`. Fine for MVP, upgrade later.
+adforge is provider-neutral. Any one of the keys below activates the hero-image pipeline. If the user already has one, use that — don't push a new signup. If they have none and want generated heroes, recommend based on what they care about:
+
+| Key                     | Provider                       | Default model                | Get a key                                |
+|-------------------------|--------------------------------|------------------------------|------------------------------------------|
+| `BFL_API_KEY`           | Black Forest Labs (FLUX)       | flux-2-max                   | https://dashboard.bfl.ai/keys            |
+| `GEMINI_API_KEY`        | Google Gemini / Nano Banana    | gemini-2.5-flash-image       | https://aistudio.google.com/apikey       |
+| `OPENAI_API_KEY`        | OpenAI Images                  | gpt-image-1                  | https://platform.openai.com/api-keys     |
+| `REPLICATE_API_TOKEN`   | Replicate (unified gateway)    | google/nano-banana-2         | https://replicate.com/account/api-tokens |
+| `STABILITY_API_KEY`     | Stability AI                   | stable-image-core            | https://platform.stability.ai/account/keys |
+| `FAL_KEY`               | fal.ai                         | fal-ai/flux/schnell          | https://fal.ai/dashboard/keys            |
+
+Auto-detection order: BFL → Google → OpenAI → Replicate → Stability → fal. To force a provider regardless of which keys are set, add `IMAGE_PROVIDER=<name>` to `.env`. To change the model within a provider, set `<PROVIDER>_MODEL` (e.g. `REPLICATE_MODEL=black-forest-labs/flux-schnell`).
+
+**If no key is set:** creatives still render — use `hero_mode: "flat_brand_color"` in variants. Fine for MVP, upgrade later.
+
+**Bringing a provider adforge doesn't have built-in?** Invoke `image-provider-synth` — it writes a new `engines/static/image_providers/<name>.py` adapter from the provider's official docs.
 
 ### `META_ACCESS_TOKEN` (required for deploy)
 

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -103,6 +103,7 @@ expected=(
   ".claude/skills/performance-analyst/SKILL.md"
   ".claude/skills/layout-synth/SKILL.md"
   ".claude/skills/motion-synth/SKILL.md"
+  ".claude/skills/image-provider-synth/SKILL.md"
   ".claude/commands/adforge.md"
 )
 


### PR DESCRIPTION
## Summary

PR 3 of 5 for the provider-neutral image pipeline (v0.3.0 track).

- **`setup/SKILL.md`** — swaps the BFL-only keys section for a matrix covering all six built-ins (BFL, Google/Nano Banana, OpenAI, Replicate, Stability, fal), the auto-detection order, and `IMAGE_PROVIDER` + `<PROVIDER>_MODEL` overrides. Adds a pointer to `image-provider-synth` when the user's provider isn't in the built-in set.
- **`composer-speccer/SKILL.md`** — `hero_mode` guidance no longer tied to a single provider. Any image-provider key unlocks generated heroes; otherwise fall back to `flat_brand_color`.
- **`new-campaign/SKILL.md`** — key-check step now lists all six provider keys, names `IMAGE_PROVIDER`, and points at `image-provider-synth`.
- **`image-provider-synth/SKILL.md`** (new) — backend skill that writes a new `engines/static/image_providers/<name>.py` adapter from official docs for providers adforge doesn't ship. Hard rule, repeated from `CONTRACT.md`: build only from provider docs / official GitHub / OpenAPI specs — never training-data recall, SO, Medium. Mirrors the sync (`openai.py`) or queue (`bfl.py` / `fal.py`) reference adapter depending on provider style. Width/height is always mapped to the closest aspect or size the provider supports.

## Test plan

- [x] `./test/run-tests.sh --skip-motion` — **35/35 pass**
- [x] Scaffold expected-file list includes `image-provider-synth/SKILL.md` (now 48 expected files, up from 47).

## What this does NOT do

- No README / CHANGELOG / version bump — those bundle with PR 5 so the release commit is a clean `v0.3.0` stamp.
- No `adforge upgrade` command — PR 4 (issue #15).
- No CI release via OIDC — PR 5 (issue #16). That PR publishes 0.3.0 to npm with provenance.