### PR TITLE
feat(cli): adforge upgrade command (closes #15)

### DIFF
--- a/bin/adforge.js
+++ b/bin/adforge.js
@@ -3,18 +3,55 @@
  * adforge CLI
  *
  * Subcommands:
- *   init <dir>    scaffold a new project
- *   doctor        check runtime deps (python, pillow, node, remotion)
- *   --version     print version
- *   --help        usage
+ *   init <dir>          scaffold a new project
+ *   upgrade [--dry-run] upgrade an existing project to the current CLI version
+ *   doctor              check runtime deps (python, pillow, node, remotion)
+ *   --version           print version
+ *   --help              usage
  */
 
 const fs = require("fs");
 const path = require("path");
+const crypto = require("crypto");
 const { execSync } = require("child_process");
 
 const PKG = require("../package.json");
 const TEMPLATES = path.join(__dirname, "..", "templates");
+
+// Files shipped with the CLI where the agent owns the authoritative version.
+// On upgrade we want the newer content — but never clobber local edits, so we
+// fall back to a `.new` sibling whenever the local copy is modified.
+const OVERWRITE_PREFIXES = [
+  ".claude/skills/",
+  ".claude/commands/",
+  "engines/static/shared.py",
+  "engines/static/compose.py",
+  "engines/static/flux.sh",
+  "engines/static/generate_hero.py",
+  "engines/static/image_providers/",
+  "engines/static/requirements.txt",
+  "engines/motion/src/primitives/",
+  "engines/motion/src/Root.tsx",
+  "engines/motion/render.sh",
+  "engines/motion/package.json",
+  "adapters/meta/",
+  "AGENTS.md",
+  "README.md",
+  ".env.example", // source is templates/env.example
+  ".gitignore",   // source is templates/gitignore
+];
+
+// Examples are starting points — users fork / edit them. Copy on init, leave
+// alone on upgrade. New examples shipped in later CLI versions are still added.
+const ADD_ONLY_PREFIXES = [
+  "engines/static/examples/",
+  "engines/motion/src/examples/",
+  "variants/",
+];
+
+// Anything not matching a prefix above is user-owned and never touched:
+// brand.json, adforge.config.json, outputs/, .adforge/ (besides manifest),
+// assets/, fonts/, .env, etc.
 
 function log(msg) {
   process.stdout.write(msg + "\n");
@@ -29,16 +66,21 @@ function usage() {
 
 Usage:
   adforge init <project-dir>    Scaffold a new project
+  adforge upgrade [--dry-run]   Upgrade an existing project to the current CLI version
   adforge doctor                Check runtime dependencies
   adforge --version             Print version
   adforge --help                Show this message
 
 After init:
   cd <project-dir>
-  cp .env.example .env          # fill in BFL_API_KEY, META_ACCESS_TOKEN, ...
+  cp .env.example .env          # fill in image-provider key, META_ACCESS_TOKEN, ...
   claude                        # or: codex
 
 Then tell the agent: "start adforge"`);
+}
+
+function sha256OfFile(p) {
+  return crypto.createHash("sha256").update(fs.readFileSync(p)).digest("hex");
 }
 
 function copyDir(src, dest) {
@@ -51,6 +93,61 @@ function copyDir(src, dest) {
     } else {
       fs.copyFileSync(s, d);
     }
+  }
+}
+
+function walkTemplateFiles() {
+  // Returns [{ templatePath, projectRelPath }] for every file under TEMPLATES.
+  // projectRelPath rewrites gitignore/env.example to .gitignore/.env.example
+  // so it matches what init materialises on disk.
+  const out = [];
+  function walk(dir, relParts) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const abs = path.join(dir, entry.name);
+      const parts = [...relParts, entry.name];
+      if (entry.isDirectory()) {
+        walk(abs, parts);
+      } else {
+        let rel = parts.join("/");
+        if (rel === "gitignore") rel = ".gitignore";
+        else if (rel === "env.example") rel = ".env.example";
+        out.push({ templatePath: abs, projectRelPath: rel });
+      }
+    }
+  }
+  walk(TEMPLATES, []);
+  return out;
+}
+
+function classifyPath(rel) {
+  for (const p of OVERWRITE_PREFIXES) {
+    if (rel === p || rel.startsWith(p)) return "overwrite";
+  }
+  for (const p of ADD_ONLY_PREFIXES) {
+    if (rel === p || rel.startsWith(p)) return "add-only";
+  }
+  return "skip";
+}
+
+function writeManifest(projectDir, templateEntries) {
+  const manifest = { version: PKG.version, files: {} };
+  for (const { templatePath, projectRelPath } of templateEntries) {
+    if (classifyPath(projectRelPath) === "skip") continue;
+    manifest.files[projectRelPath] = sha256OfFile(templatePath);
+  }
+  const adforgeDir = path.join(projectDir, ".adforge");
+  fs.mkdirSync(adforgeDir, { recursive: true });
+  fs.writeFileSync(path.join(adforgeDir, "manifest.json"), JSON.stringify(manifest, null, 2) + "\n");
+  fs.writeFileSync(path.join(adforgeDir, "version"), PKG.version + "\n");
+}
+
+function readManifest(projectDir) {
+  const p = path.join(projectDir, ".adforge", "manifest.json");
+  if (!fs.existsSync(p)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8"));
+  } catch (e) {
+    return null;
   }
 }
 
@@ -70,7 +167,6 @@ function cmdInit(targetDir) {
   }
   log(`scaffolding adforge project at ${abs}`);
   copyDir(TEMPLATES, abs);
-  // Rename dotfiles that npm strips
   const gitignoreSrc = path.join(abs, "gitignore");
   if (fs.existsSync(gitignoreSrc)) {
     fs.renameSync(gitignoreSrc, path.join(abs, ".gitignore"));
@@ -79,6 +175,7 @@ function cmdInit(targetDir) {
   if (fs.existsSync(envExampleSrc)) {
     fs.renameSync(envExampleSrc, path.join(abs, ".env.example"));
   }
+  writeManifest(abs, walkTemplateFiles());
   log(`
   done.
 
@@ -89,6 +186,101 @@ function cmdInit(targetDir) {
 
   in the agent: "start adforge"
 `);
+}
+
+function cmdUpgrade(args) {
+  const dryRun = args.includes("--dry-run");
+  const projectDir = process.cwd();
+
+  // Cheap sanity check — only run in something that looks like an adforge project.
+  if (!fs.existsSync(path.join(projectDir, "adforge.config.json"))) {
+    err(`error: not an adforge project (no adforge.config.json in ${projectDir})`);
+    process.exit(1);
+  }
+
+  const manifest = readManifest(projectDir);
+  const entries = walkTemplateFiles();
+
+  const actions = { add: [], overwrite: [], newSibling: [], upToDate: [], skip: [] };
+
+  for (const { templatePath, projectRelPath } of entries) {
+    const cls = classifyPath(projectRelPath);
+    const projectAbs = path.join(projectDir, projectRelPath);
+    const exists = fs.existsSync(projectAbs);
+
+    if (cls === "skip") {
+      actions.skip.push(projectRelPath);
+      continue;
+    }
+
+    if (!exists) {
+      // File is new in this CLI version, regardless of layer — copy it in.
+      actions.add.push({ projectRelPath, templatePath, projectAbs });
+      continue;
+    }
+
+    if (cls === "add-only") {
+      // Already there, user owns it — leave alone.
+      actions.skip.push(projectRelPath);
+      continue;
+    }
+
+    // Overwrite layer with existing local file: compare hashes.
+    const templateHash = sha256OfFile(templatePath);
+    const projectHash = sha256OfFile(projectAbs);
+    if (templateHash === projectHash) {
+      actions.upToDate.push(projectRelPath);
+      continue;
+    }
+
+    const recordedHash = manifest && manifest.files ? manifest.files[projectRelPath] : null;
+    if (recordedHash && recordedHash === projectHash) {
+      // Local file is pristine at the recorded version — template moved, safe to overwrite.
+      actions.overwrite.push({ projectRelPath, templatePath, projectAbs });
+    } else {
+      // Unknown or modified locally → write a .new sibling so the user can diff.
+      actions.newSibling.push({ projectRelPath, templatePath, projectAbs });
+    }
+  }
+
+  const fromVersion = manifest && manifest.version ? manifest.version : "unknown";
+  log(`adforge upgrade: ${fromVersion} -> ${PKG.version}${dryRun ? "  (dry run)" : ""}`);
+  log("");
+
+  const print = (label, items, fmt) => {
+    if (!items.length) return;
+    log(`  ${label} (${items.length})`);
+    for (const it of items) log(`    ${fmt(it)}`);
+    log("");
+  };
+
+  print("add (new file)", actions.add, a => a.projectRelPath);
+  print("overwrite (template moved, no local edits)", actions.overwrite, a => a.projectRelPath);
+  print("review (local edits detected — writing .new sibling)", actions.newSibling, a => `${a.projectRelPath} -> ${a.projectRelPath}.new`);
+  if (actions.upToDate.length) log(`  up-to-date: ${actions.upToDate.length} file(s)`);
+
+  if (dryRun) {
+    log("\n(dry run — no files written)");
+    return;
+  }
+
+  for (const { templatePath, projectAbs } of actions.add) {
+    fs.mkdirSync(path.dirname(projectAbs), { recursive: true });
+    fs.copyFileSync(templatePath, projectAbs);
+  }
+  for (const { templatePath, projectAbs } of actions.overwrite) {
+    fs.copyFileSync(templatePath, projectAbs);
+  }
+  for (const { templatePath, projectAbs } of actions.newSibling) {
+    fs.copyFileSync(templatePath, projectAbs + ".new");
+  }
+
+  writeManifest(projectDir, entries);
+
+  log(`\ndone. ${PKG.version} now recorded in .adforge/manifest.json.`);
+  if (actions.newSibling.length) {
+    log(`review ${actions.newSibling.length} .new file(s) and diff against your edited versions.`);
+  }
 }
 
 function cmdDoctor() {
@@ -133,6 +325,8 @@ function main() {
   switch (cmd) {
     case "init":
       return cmdInit(rest[0]);
+    case "upgrade":
+      return cmdUpgrade(rest);
     case "doctor":
       return cmdDoctor();
     case "--version":

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -152,6 +152,99 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Test 1b — adforge upgrade (manifest + edit detection + .new sibling)
+# ---------------------------------------------------------------------------
+head "Test 1b: adforge upgrade"
+
+# init writes manifest
+if [ -f "$PROJECT/.adforge/manifest.json" ] && [ -f "$PROJECT/.adforge/version" ]; then
+  pass ".adforge/manifest.json + version written on init"
+else
+  fail ".adforge manifest/version missing after init"
+fi
+
+MANIFEST_FILES=$(python3 -c "import json; print(len(json.load(open('$PROJECT/.adforge/manifest.json'))['files']))")
+if [ "$MANIFEST_FILES" -gt 40 ]; then
+  pass "manifest tracks $MANIFEST_FILES files"
+else
+  fail "manifest tracks only $MANIFEST_FILES files (expected >40)"
+fi
+
+# Pristine upgrade: should be entirely up-to-date, no .new files written
+if (cd "$PROJECT" && node "$REPO/bin/adforge.js" upgrade --dry-run > "$WORK/upgrade-pristine.log" 2>&1); then
+  pass "upgrade --dry-run exited 0"
+else
+  fail "upgrade --dry-run exit code"
+  cat "$WORK/upgrade-pristine.log"
+fi
+
+if grep -q "up-to-date:" "$WORK/upgrade-pristine.log" && ! grep -q "review (" "$WORK/upgrade-pristine.log"; then
+  pass "pristine project reports all up-to-date"
+else
+  fail "pristine upgrade reported unexpected changes"
+  cat "$WORK/upgrade-pristine.log"
+fi
+
+# dry-run must not write anything
+if [ ! -e "$PROJECT/AGENTS.md.new" ]; then
+  pass "--dry-run wrote no files"
+else
+  fail "--dry-run created AGENTS.md.new"
+fi
+
+# Modify a tracked overwrite-layer file → upgrade must write .new sibling, keep local file intact
+cp "$PROJECT/AGENTS.md" "$WORK/AGENTS-original.md"
+echo "# local edit" >> "$PROJECT/AGENTS.md"
+
+if (cd "$PROJECT" && node "$REPO/bin/adforge.js" upgrade > "$WORK/upgrade-edited.log" 2>&1); then
+  pass "upgrade (with local edit) exited 0"
+else
+  fail "upgrade (with local edit) exit code"
+  cat "$WORK/upgrade-edited.log"
+fi
+
+if [ -f "$PROJECT/AGENTS.md.new" ]; then
+  pass ".new sibling written for edited file"
+else
+  fail "AGENTS.md.new not created"
+fi
+
+if grep -q "# local edit" "$PROJECT/AGENTS.md"; then
+  pass "local edit preserved (AGENTS.md untouched)"
+else
+  fail "local edit to AGENTS.md was clobbered"
+fi
+
+# User-owned files (brand.json) must never be touched by upgrade.
+# Use a throwaway file so we don't poison downstream tests that need brand.json.
+cp "$PROJECT/brand.json" "$WORK/brand-backup.json"
+echo '{"custom":"user work"}' > "$PROJECT/brand.json"
+(cd "$PROJECT" && node "$REPO/bin/adforge.js" upgrade > "$WORK/upgrade-userfile.log" 2>&1) || true
+if grep -q '"custom":"user work"' "$PROJECT/brand.json"; then
+  pass "user-owned brand.json preserved"
+else
+  fail "brand.json was clobbered"
+fi
+cp "$WORK/brand-backup.json" "$PROJECT/brand.json"
+
+# Delete a tracked file → upgrade should re-add it (add path)
+rm "$PROJECT/AGENTS.md" "$PROJECT/AGENTS.md.new"
+(cd "$PROJECT" && node "$REPO/bin/adforge.js" upgrade > "$WORK/upgrade-readd.log" 2>&1) || true
+if [ -f "$PROJECT/AGENTS.md" ] && grep -q "add (new file)" "$WORK/upgrade-readd.log"; then
+  pass "missing tracked file re-added on upgrade"
+else
+  fail "AGENTS.md not re-added"
+fi
+
+# Upgrade refuses outside an adforge project
+(cd "$WORK" && node "$REPO/bin/adforge.js" upgrade > "$WORK/upgrade-nonproject.log" 2>&1) && rc=0 || rc=$?
+if [ "$rc" -ne 0 ] && grep -q "not an adforge project" "$WORK/upgrade-nonproject.log"; then
+  pass "upgrade refuses when not in adforge project"
+else
+  fail "upgrade should refuse outside adforge project (rc=$rc)"
+fi
+
+# ---------------------------------------------------------------------------
 # Test 2 — static compose (advertorial example, 4x5)
 # ---------------------------------------------------------------------------
 head "Test 2: static compose"


### PR DESCRIPTION
## Summary

- `adforge upgrade` pulls template changes from a newer CLI version into an existing project without clobbering local edits.
- `init` now writes `.adforge/manifest.json` (SHA-256 per file + version), so upgrade can distinguish pristine template files from locally-edited ones.
- Three-layer classification per file: **overwrite** (template authoritative — `.claude/skills/`, `engines/`, `adapters/`, `AGENTS.md`, …), **add-only** (starting points — `engines/static/examples/`, `variants/`), **skip** (user-owned — `brand.json`, `outputs/`, `.env`, …).

## Behavior matrix

| Local state | Overwrite layer | Add-only layer |
|---|---|---|
| Missing | copy in (**add**) | copy in (**add**) |
| Present, hash == template | leave (**up-to-date**) | leave |
| Present, hash == manifest (pristine) | overwrite with new template | leave |
| Present, hash diverges from manifest (edited) | write `.new` sibling, leave local alone | leave |

`upgrade --dry-run` previews without writing. Refuses to run when `adforge.config.json` is absent.

## Test plan

Test 1b (`test/run-tests.sh`) covers:
- [x] init writes `.adforge/manifest.json` + `.adforge/version`
- [x] manifest tracks all overwrite + add-only files
- [x] pristine upgrade reports all files up-to-date
- [x] `--dry-run` writes no files
- [x] locally-edited file → `.new` sibling written, local file intact
- [x] user-owned files (`brand.json`) never touched
- [x] missing tracked file re-added on upgrade
- [x] upgrade refuses outside an adforge project

46/46 tests pass (`--skip-motion`).

Closes #15.