### PR TITLE
release: v0.3.0 — provider-neutral image gen + upgrade command + OIDC release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write      # OIDC — required for npm trusted publishing + provenance
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: run test harness (skip motion render)
+        run: ./test/run-tests.sh --skip-motion
+
+      - name: verify tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(node -p "require('./package.json').version")
+          if [ "$TAG" != "$PKG" ]; then
+            echo "tag v$TAG does not match package.json version $PKG"
+            exit 1
+          fi
+
+      - name: publish to npm with provenance
+        run: npm publish --provenance --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.3.0 — 2026-04-21
+
+Provider-neutral image generation, an in-place upgrade path for existing projects, and signed releases via OIDC. The v0.2.0 README already promised "any provider works" — this release actually delivers it.
+
+### Added
+
+- **Six built-in image providers.** Drop any one key into `.env` and generation works end-to-end: `BFL_API_KEY` (flux-2-max), `GEMINI_API_KEY` (gemini-2.5-flash-image / Nano Banana), `OPENAI_API_KEY` (gpt-image-1), `REPLICATE_API_TOKEN` (google/nano-banana-2), `STABILITY_API_KEY` (stable-image-core), `FAL_KEY` (fal-ai/flux/schnell). Auto-detection order: BFL → Google → OpenAI → Replicate → Stability → fal. Force a provider with `IMAGE_PROVIDER=<name>`, swap the default model per provider via `<PROVIDER>_MODEL`.
+- **Provider dispatcher** (`engines/static/generate_hero.py`) — one entry point, dynamically loads the adapter matching the detected/pinned provider. Each adapter lives at `engines/static/image_providers/<name>.py`, stdlib-only, single `generate(prompt, width, height) -> bytes` contract. `engines/static/image_providers/CONTRACT.md` pins the contract; `flux.sh` is kept as a thin backcompat wrapper.
+- **`image-provider-synth` skill** — when a user has a key for a provider adforge doesn't ship (Mistral, Ideogram, Azure OpenAI, Bedrock, Cloudflare Workers AI, self-hosted Comfy, …), the agent writes a new adapter from the provider's official docs. Docs-only rule (no training-data recall, no blog-post sources), verification date stamped in the header, shape-test pattern mirrors the built-ins.
+- **`adforge upgrade` command** — pulls template changes from a newer CLI version into an existing project without clobbering local edits.
+  - `init` now writes `.adforge/manifest.json` (SHA-256 per file + version) so upgrade can distinguish pristine template files from locally-edited ones.
+  - Three-layer classification: **overwrite** (template authoritative — `.claude/skills/`, `engines/`, `adapters/`, `AGENTS.md`, …), **add-only** (starting points — `engines/static/examples/`, `variants/`), **skip** (user-owned — `brand.json`, `outputs/`, `.env`, …).
+  - Edited overwrite-layer files get a `.new` sibling instead of being clobbered; the user diffs at their own pace.
+  - `adforge upgrade --dry-run` previews without writing. Refuses to run outside an adforge project.
+- **Signed releases via OIDC trusted publisher.** `.github/workflows/release.yml` triggers on `v*` tags, runs the test harness, and publishes to npm with `--provenance`. No `NPM_TOKEN` secret needed; provenance badge links every published tarball to its commit + workflow run.
+
+### Changed
+
+- **Setup flow onboards any provider.** `.claude/skills/setup/SKILL.md` walks through the full provider matrix with the exact dashboard URL per vendor, explains auto-detection order, and documents the `IMAGE_PROVIDER` pin. Flat-brand-color remains the zero-key fallback.
+- **`new-campaign` + `composer-speccer` skills** check all six provider keys in the pre-flight and recommend `image-provider-synth` when the user brings a non-built-in provider.
+- **Test harness** covers the dispatcher, BFL live shape, and mock-HTTP shape tests for all 5 newly-added providers — 46 assertions, CI-green on `--skip-motion`.
+
+### Fixed
+
+- v0.2.0 claimed provider-neutrality in the README but only BFL was actually wired. Claim now matches implementation.
+
 ## 0.2.0 — 2026-04-20
 
 Breaks the "templates" paradigm. Layouts and motion compositions are now **reference implementations** the agent forks and adapts, not fixed templates every brand reskins. Also: proper font handling from day one, first-class custom + lookalike audiences, and a fallback path when users don't have a Meta token yet.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ adforge degrades gracefully — you can start without any keys and still render 
 - Python 3 with Pillow (`pip install Pillow`)
 - ffmpeg (for motion renders)
 
-**API keys (optional, unlock Meta deploy + AI hero images):**
+**Meta deploy keys (optional — unlock live ads):**
 
 | Key | What it unlocks | How to get it |
 |-----|-----------------|---------------|
@@ -25,11 +25,25 @@ adforge degrades gracefully — you can start without any keys and still render 
 | `META_AD_ACCOUNT_ID` | Same as above — target account | Ads Manager → Account Settings (format: `act_1234...`) |
 | `META_PAGE_ID` | Page to run ads from | Your FB page → About → Page ID |
 | `META_PIXEL_ID` *(optional)* | Conversion-optimized campaigns | Events Manager → Data Sources → Pixel ID |
-| `BFL_API_KEY` *(optional, tested default)* | AI-generated hero images via Flux | [bfl.ml/api](https://bfl.ml/api) (pay-as-you-go) |
 
-**On hero images:** Flux (BFL) is the tested default — that's what we've validated end-to-end. It's not required. adforge doesn't care where the PNG comes from: drop in OpenAI / Ideogram / Midjourney exports, a Figma render, or a flat `hero_mode: "radiant_gradient"` and the rest of the pipeline works the same.
+**Image-generation keys (optional — any *one* unlocks AI heroes):**
 
-**Without any keys:** you can still scaffold, render static + motion creatives, and iterate locally. You just can't deploy to Meta or auto-generate heroes inside the pipeline.
+adforge is provider-neutral. Drop any one of the keys below into `.env` and generation works end-to-end. Auto-detection order is BFL → Google → OpenAI → Replicate → Stability → fal; force a specific provider with `IMAGE_PROVIDER=<name>`, swap the default model per provider via `<PROVIDER>_MODEL`.
+
+| Key | Provider | Default model | Get a key |
+|-----|----------|---------------|-----------|
+| `BFL_API_KEY` | Black Forest Labs (FLUX) | `flux-2-max` | [dashboard.bfl.ai/keys](https://dashboard.bfl.ai/keys) |
+| `GEMINI_API_KEY` | Google Gemini / Nano Banana | `gemini-2.5-flash-image` | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) |
+| `OPENAI_API_KEY` | OpenAI Images | `gpt-image-1` | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
+| `REPLICATE_API_TOKEN` | Replicate | `google/nano-banana-2` | [replicate.com/account/api-tokens](https://replicate.com/account/api-tokens) |
+| `STABILITY_API_KEY` | Stability AI | `stable-image-core` | [platform.stability.ai/account/keys](https://platform.stability.ai/account/keys) |
+| `FAL_KEY` | fal.ai | `fal-ai/flux/schnell` | [fal.ai/dashboard/keys](https://fal.ai/dashboard/keys) |
+
+Bringing a provider not on this list (Mistral, Ideogram, Azure OpenAI, Bedrock, Cloudflare Workers AI, a self-hosted Comfy endpoint, …)? Ask the agent to run `image-provider-synth` — it reads the provider's official docs and writes a new adapter under `engines/static/image_providers/<name>.py` that the dispatcher picks up automatically.
+
+**Without any image-generation key:** creatives still render — set `hero_mode: "flat_brand_color"` in variants. Fine for MVP.
+
+**Without any keys at all:** you can still scaffold, render static + motion creatives, and iterate locally. You just can't deploy to Meta or auto-generate heroes inside the pipeline.
 
 ## Install
 
@@ -82,10 +96,13 @@ adforge is that stack, extracted once, reusable. Tell an agent what you want, ge
 ## Commands
 
 ```bash
-npx adforge init <dir>      # scaffold a new project
-npx adforge doctor          # check Python, Node, ffmpeg, env vars
+npx adforge init <dir>            # scaffold a new project
+npx adforge upgrade [--dry-run]   # pull template updates into an existing project
+npx adforge doctor                # check Python, Node, ffmpeg, env vars
 npx adforge --version
 ```
+
+`adforge upgrade` compares every template-layer file against the recorded hash in `.adforge/manifest.json`. Pristine files get overwritten in place; locally-edited files get a `.new` sibling so you can diff at your own pace. User-owned files (`brand.json`, `variants/`, `outputs/`, `.env`) are never touched.
 
 Everything else — rendering, deploying, reviewing — happens through the agent, or directly via the scripts in `engines/` and `adapters/`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adforge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Brief-to-live-ad pipeline for Meta — runs inside Claude Code, Codex, or any agent. Static + motion creatives, idempotent deploy.",
   "bin": {
     "adforge": "bin/adforge.js"


### PR DESCRIPTION
## Summary

Final PR for the v0.3.0 release. Bundles docs/version/CHANGELOG with the OIDC publish workflow (issue #16) so the release commit is a coherent 0.3.0 stamp. Once merged, pushing `v0.3.0` triggers the workflow, which runs the test harness and publishes to npm with `--provenance`.

## Changes

- `package.json` — 0.2.0 → 0.3.0
- `CHANGELOG.md` — 0.3.0 entry covering:
  - Six built-in image providers (BFL, Google, OpenAI, Replicate, Stability, fal) + `IMAGE_PROVIDER` pin + `<PROVIDER>_MODEL` override
  - `image-provider-synth` skill for bring-your-own providers
  - `adforge upgrade` command + `.adforge/manifest.json`
  - OIDC trusted publisher + provenance badge
- `README.md`
  - Split prerequisites: Meta keys table vs. image-generation matrix (6 providers × default model × dashboard URL)
  - `image-provider-synth` pointer for unsupported providers
  - `adforge upgrade` documented in Commands section
- `.github/workflows/release.yml`
  - Triggers on `v*` tag push
  - `permissions: id-token: write` (OIDC requirement)
  - Runs `./test/run-tests.sh --skip-motion`
  - Verifies tag matches `package.json` version before publishing
  - `npm publish --provenance --access public`

## Release procedure after merge

1. Merge this PR to `main`.
2. Configure npm trusted publisher at npmjs.com/package/adforge/access → GitHub Actions → repo `JonnyFi/adforge`, workflow `release.yml`. One-time.
3. `git tag v0.3.0 && git push origin v0.3.0` → workflow fires, publishes to npm with provenance.
4. Open GitHub Release on tag, paste the CHANGELOG 0.3.0 section.

## Test plan

- [x] `./test/run-tests.sh --skip-motion` — 46/46 passing
- [x] `node -c bin/adforge.js` — syntax ok
- [x] Tag-match guard verified by construction (workflow exits 1 if tag ≠ package.json version)
- [ ] Trusted-publisher configuration on npmjs.com (one-time, done after merge)

Closes #16.