### PR TITLE
fix(cli): upgrade gaps + init clobber + doctor node floor + release.yml guard order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - "v*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   publish:
@@ -19,6 +19,15 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
+      - name: verify tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(node -p "require('./package.json').version")
+          if [ "$TAG" != "$PKG" ]; then
+            echo "tag v$TAG does not match package.json version $PKG"
+            exit 1
+          fi
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -28,15 +37,6 @@ jobs:
 
       - name: run test harness (skip motion render)
         run: ./test/run-tests.sh --skip-motion
-
-      - name: verify tag matches package.json version
-        run: |
-          TAG="${GITHUB_REF_NAME#v}"
-          PKG=$(node -p "require('./package.json').version")
-          if [ "$TAG" != "$PKG" ]; then
-            echo "tag v$TAG does not match package.json version $PKG"
-            exit 1
-          fi
 
       - name: publish to npm with provenance
         run: npm publish --provenance --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.3.1 — 2026-04-21
+
+Post-release fix pass driven by a Karpathy-style 3-stage LLM council audit. Six criticals (Meta adapter compliance + rendering correctness) plus tooling hardening.
+
+### Fixed
+
+- **Meta Customer Audiences upload now conforms to Customer List Terms.** `adapters/meta/deploy.py::upload_customer_file` validates CSV headers against Meta's schema (`EMAIL/PHONE/FN/LN/CT/ST/ZIP/COUNTRY/DOBY/DOBM/DOBD/GEN/MADID/EXTERN_ID`), accepts German aliases (`vorname→FN`, `plz→ZIP`, `land→COUNTRY`, …), normalizes per-field before hashing (phone digits-only, name alpha-lowercase, ZIP first-5-for-US, COUNTRY ISO-2 lowercase, DOBM/DOBD zero-padded), and leaves `EXTERN_ID` unhashed. Unknown columns are rejected with a hint.
+- **DSGVO consent gate on custom audience creation.** `ensure_audience()` refuses to create a `custom_list` audience unless the plan carries `"consent_confirmed": true`. Art. 6/7 GDPR compliance is not optional and can't be assumed from a CSV filename.
+- **Video upload waits for Meta processing before creating the ad.** `Meta.upload_video()` polls `GET /{video_id}?fields=status` until `video_status=="ready"` (300s timeout, 4s interval). Previously the ad creative could reference a still-encoding video and fail silently.
+- **Leads metric no longer triple-counts.** `adapters/meta/review.py` counts only the top-level `lead` action_type; Meta already rolls up `onsite_conversion.lead_grouped` and `offsite_conversion.fb_pixel_lead` into it.
+- **Brand fonts actually render in Remotion.** `engines/motion/src/Root.tsx` previously injected `@font-face` as a sibling of `<Composition>` in `registerRoot()` — which never reaches the render iframe. Fonts now ship via a `withBrandFonts(...)` HOC wrapped around each `component={...}`, so `<style>` lives inside the composition tree.
+- **BFL default model demoted to `flux-2-pro`.** `flux-2-max` is the flagship (billed accordingly); `flux-2-pro` is the mid-tier per CONTRACT.md:25 ("not the cheapest or the flagship"). Env var / docs / test harness aligned.
+- **Radiant-gradient hero mode guards against missing brand block.** `engines/static/shared.py` warns and falls back to flat_brand_color when `hero_mode="radiant_gradient"` is set but `brand.json` has no `radiant_gradient` config. Previously crashed with `TypeError`.
+- **Pillow version pinned** to `>=10.1.0,<12.0.0` in `engines/static/requirements.txt` to avoid the 10.0.x `ImageFont.load_default(size=)` regression.
+- **Motion is 9:16-only**, per Meta's placement algorithm (Reels / Stories / Feed auto-crops). `new-campaign` skill and `motion-synth` skill updated. `phone-notifications` composition registered in `adforge.config.json`.
+
+### Changed
+
+- **`adforge doctor` checks for CLI updates.** Hits `https://registry.npmjs.org/adforge/latest` (2s timeout, swallows offline errors) and prints an upgrade hint when a newer version exists. Node major-version is now actually compared against the `>=18` floor instead of just being annotated.
+- **`adforge init` refuses to scaffold into directories containing dotfiles.** Previously filtered `.` entries out of the emptiness check and could silently clobber pre-existing `.env.example`, `.gitignore`, or `.claude/`.
+- **CLI overwrite layer now covers all motion root files** — `engines/motion/tsconfig.json`, `remotion.config.ts`, `src/index.ts`, `src/brand.ts(x)` — so `adforge upgrade` pulls framework-level changes instead of leaving projects on stale Remotion config.
+- **Release workflow tightened.** Tag-vs-package.json guard moved before the test harness (fail fast on version mismatch). Trigger narrowed from `v*` to strict semver `v[0-9]+.[0-9]+.[0-9]+` so RC tags or typos don't accidentally publish.
+
 ## 0.3.0 — 2026-04-21
 
 Provider-neutral image generation, an in-place upgrade path for existing projects, and signed releases via OIDC. The v0.2.0 README already promised "any provider works" — this release actually delivers it.

--- a/bin/adforge.js
+++ b/bin/adforge.js
@@ -32,6 +32,11 @@ const OVERWRITE_PREFIXES = [
   "engines/static/requirements.txt",
   "engines/motion/src/primitives/",
   "engines/motion/src/Root.tsx",
+  "engines/motion/src/index.ts",
+  "engines/motion/src/brand.ts",
+  "engines/motion/src/brand.tsx",
+  "engines/motion/tsconfig.json",
+  "engines/motion/remotion.config.ts",
   "engines/motion/render.sh",
   "engines/motion/package.json",
   "adapters/meta/",
@@ -159,7 +164,9 @@ function cmdInit(targetDir) {
   }
   const abs = path.resolve(targetDir);
   if (fs.existsSync(abs)) {
-    const entries = fs.readdirSync(abs).filter(n => !n.startsWith("."));
+    // Dotfiles count too — scaffolding writes .env.example, .gitignore, .claude/,
+    // .adforge/ and would otherwise silently overwrite pre-existing ones.
+    const entries = fs.readdirSync(abs);
     if (entries.length) {
       err(`error: ${abs} exists and is not empty`);
       process.exit(1);
@@ -283,9 +290,29 @@ function cmdUpgrade(args) {
   }
 }
 
-function cmdDoctor() {
+async function checkLatestVersion() {
+  // Node 18+ has global fetch. Swallow any network/parse error — doctor
+  // is diagnostic, not blocking; a stale npm mirror shouldn't fail it.
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 2000);
+    const res = await fetch("https://registry.npmjs.org/adforge/latest", {
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+    if (!res.ok) return;
+    const { version } = await res.json();
+    if (version && version !== PKG.version) {
+      log(`  \u25cb adforge ${PKG.version} installed, ${version} available — npx adforge@latest upgrade`);
+    }
+  } catch (_) {
+    // offline / blocked / aborted — stay quiet
+  }
+}
+
+async function cmdDoctor() {
   const required = [
-    { name: "node", cmd: "node --version", min: "18" },
+    { name: "node", cmd: "node --version", minMajor: 18 },
     { name: "python3", cmd: "python3 --version" },
     { name: "pip", cmd: "pip3 --version" },
     { name: "ffmpeg (for Remotion)", cmd: "ffmpeg -version" },
@@ -302,6 +329,15 @@ function cmdDoctor() {
   for (const c of required) {
     try {
       const out = execSync(c.cmd, { stdio: ["ignore", "pipe", "ignore"] }).toString().split("\n")[0];
+      if (c.minMajor) {
+        const m = out.match(/(\d+)\.(\d+)\.(\d+)/);
+        const major = m ? parseInt(m[1], 10) : null;
+        if (major !== null && major < c.minMajor) {
+          ok = false;
+          log(`  \u2717 ${c.name.padEnd(32)} ${out} (need >=${c.minMajor})`);
+          continue;
+        }
+      }
       log(`  \u2713 ${c.name.padEnd(32)} ${out}`);
     } catch (e) {
       ok = false;
@@ -316,6 +352,7 @@ function cmdDoctor() {
       log(`  \u25cb ${c.name.padEnd(32)} not installed (optional) — ${c.hint}`);
     }
   }
+  await checkLatestVersion();
   log(ok ? "\nall required deps present." : "\nsome required deps missing — install them and retry.");
   process.exit(ok ? 0 : 1);
 }

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -15,12 +15,14 @@ That is the hub. It routes to 4 mode skills depending on what the user wants:
 - `.claude/skills/review-performance/SKILL.md`
 - `.claude/skills/setup/SKILL.md`
 
-Mode skills compose 4 backend skills:
+Mode skills compose 6 backend skills:
 
 - `.claude/skills/creative-director/SKILL.md`
 - `.claude/skills/composer-speccer/SKILL.md`
 - `.claude/skills/performance-analyst/SKILL.md`
 - `.claude/skills/layout-synth/SKILL.md` — synthesize a new static layout from a reference image
+- `.claude/skills/motion-synth/SKILL.md` — synthesize a new Remotion composition
+- `.claude/skills/image-provider-synth/SKILL.md` — add a new hero-image provider
 
 ## Project shape
 


### PR DESCRIPTION
Third of three PRs from the v0.3.0 post-release audit. Covers CLI/tooling highs + a user-requested upgrade-notification hint.

Depends on:
- #22 (Meta adapter criticals)
- #23 (rendering criticals)

## Summary

- **`OVERWRITE_PREFIXES` gap** — motion root files (`tsconfig.json`, `remotion.config.ts`, `src/brand.ts(x)`, `src/index.ts`) were missing from the overwrite layer, so `adforge upgrade` left projects on stale Remotion config. Both `brand.ts` and `brand.tsx` are listed to cover the rename in #23.
- **`cmdInit` dotfile clobber** — emptiness check filtered out dotfiles, which meant a directory already containing `.env.example` / `.gitignore` / `.claude/` would be silently scaffolded over. Now counts dotfiles too.
- **`cmdDoctor` Node ≥18 enforcement** — `min: "18"` was annotated on the check but never actually compared. Now parses the version string and fails red when major < 18.
- **`cmdDoctor` registry check** — fetches `registry.npmjs.org/adforge/latest` with a 2s timeout and prints `adforge X installed, Y available — npx adforge@latest upgrade` when a newer version exists. Swallows offline / blocked / aborted errors (doctor is diagnostic, not blocking).
- **`.github/workflows/release.yml` guard order + trigger strictness** — tag-vs-`package.json` guard moved *before* tests so a version mismatch fails in ~10s instead of after the full harness run. Trigger narrowed from `v*` to `v[0-9]+.[0-9]+.[0-9]+` so RC tags or typos can't accidentally publish.
- **`templates/AGENTS.md`** — "4 backend skills" → "6", add motion-synth + image-provider-synth.
- **CHANGELOG 0.3.1** — consolidated entry covering all three PRs so the release commit only needs to bump `package.json`.

## Test plan

- [x] `./test/run-tests.sh --skip-motion` — 46/46 pass (no regressions from the CLI edits)
- [x] `node bin/adforge.js --version` — still prints `adforge 0.3.0`
- [x] `node bin/adforge.js --help` — usage unchanged
- [ ] CI (GitHub Actions) green on this branch
- [ ] Manual smoke after merge: run `adforge doctor` in an existing project; expect "0.3.0 installed, 0.3.1 available" once 0.3.1 is tagged

## After all three merge

1. Rebase any merge conflicts between this branch and main (order: #22 → #23 → this)
2. Bump `package.json` 0.3.0 → 0.3.1
3. Tag `v0.3.1`, push tag → OIDC workflow publishes with `--provenance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)