### PR TITLE
fix(skills): route free-text ad requests through hub, forbid bypass

### DIFF
--- a/templates/.claude/skills/adforge/SKILL.md
+++ b/templates/.claude/skills/adforge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adforge
-description: Brief-to-live-ad hub. Invoke when user says "start adforge", "adforge", or wants to work on ads/creatives/campaigns in this project.
+description: Brief-to-live-ad hub. Invoke on ANY ad/creative/variant/static/motion/reel/hero/campaign request in this project — not just the literal word "adforge". Matches phrasings like "make me a static", "draft an ad", "generate a reel", "create a creative", "something wild with X", "new variant for Y", "quick test image". Use as the entry point even for one-off requests; never bypass straight to compose.py, render.sh, generate_hero.py, or one-off scripts.
 ---
 
 # adforge — hub

--- a/templates/.claude/skills/composer-speccer/SKILL.md
+++ b/templates/.claude/skills/composer-speccer/SKILL.md
@@ -7,6 +7,12 @@ description: Backend skill — translate an approved angle into a concrete varia
 
 Turn a creative brief (from `creative-director`) into a valid variant JSON under `variants/`.
 
+## Non-negotiable
+
+- **Never write inline compose code, ad-hoc Python scripts, or direct PIL calls to produce a creative.** Every creative goes through `compose.py` (static) or `render.sh` (motion) against a real variant JSON. If no existing layout or composition fits, invoke `layout-synth` or `motion-synth` FIRST — they produce auto-discovered modules that every future user inherits. An inline script is a bandaid that makes the brand's layout disappear the moment the chat ends.
+- **Never reuse an example composition or layout for a new brand just because the copy can be swapped in.** `ops-console`, `advertorial`, `quote-card`, `stat-card`, `walkthrough`, `product-mockup` are *reference implementations*, not templates. If the brief is structurally different from any existing one — hand off to the synth skill. Two brands using the same composition with different copy = two ads that look the same.
+- **Match is structural, not topical.** A Customer-Success B2B brand and a mobile-nursing B2B brand both "fit" `ops-console` topically, but that doesn't mean the brand-specific ad should look like a dispatcher UI. Ask: does the reference or brief *structurally* call for a dispatcher, a walkthrough, an editorial, a quote? If not — synth.
+
 ## Inputs
 
 - Angle + hook + body from creative-director

--- a/templates/.claude/skills/layout-synth/SKILL.md
+++ b/templates/.claude/skills/layout-synth/SKILL.md
@@ -9,6 +9,11 @@ Turn a reference image into an executable `engines/static/examples/<name>.py`. T
 
 Layouts in `engines/static/examples/` are *reference implementations*, not templates. Each new layout should be structurally distinct from existing ones — two brands using `advertorial` should never produce ads that look identical. If a reference is a cosmetic variant of an existing layout, extend the existing schema; don't clone.
 
+## Non-negotiable
+
+- **This skill produces a module file under `engines/static/examples/<name>.py`. Always.** Never draft an inline Python script, never a one-off PIL job, never a scratch file outside the engine dir. The output has to land in the engine dir so auto-discovery picks it up and every future user of the project — including the user who ran `npx adforge init` — inherits it. A one-off script solves today's request and loses all the brand-specific layout work the moment the conversation ends.
+- **Synth means new, not rename.** If you're tempted to copy an existing layout module and change two fields, that's reuse, not synthesis — hand the brief back to `composer-speccer` to use the existing layout as-is. Synth only fires when the reference or brief is structurally different from every existing layout.
+
 ## When to invoke
 
 - User uploads an image or mockup and says "I want ads like this".

--- a/templates/.claude/skills/motion-synth/SKILL.md
+++ b/templates/.claude/skills/motion-synth/SKILL.md
@@ -7,6 +7,12 @@ description: Backend skill — read a motion reference (video, GIF, or storyboar
 
 Turn a motion reference into an executable `engines/motion/src/examples/<Name>.tsx` — a Remotion composition specific to the current brand's brief. Built on the shared `primitives/` vocabulary so new compositions don't end up as reskins of `OpsConsole`.
 
+## Non-negotiable
+
+- **This skill produces a composition file under `engines/motion/src/examples/<Name>.tsx` and registers it in `Root.tsx`. Always.** Never ship a motion creative by pointing a new brand's variant at `ops-console`, `product-mockup`, `walkthrough`, or `phone-notifications` with swapped copy. That's reskinning — the exact anti-pattern this skill exists to prevent (see "Why this exists"). The HaniCare-dispatcher look generalises: any brand that reuses `ops-console` gets the HaniCare-dispatcher look.
+- **Synth means new composition, not new variant.** If you're tempted to write `"composition": "ops-console"` in a variant JSON for a new brand, stop and run this skill instead. A variant is copy + numbers; a composition is structure + motion idiom. Brand-specific motion needs brand-specific composition.
+- **Existing example compositions are reference only.** `ops-console` / `product-mockup` / `walkthrough` / `phone-notifications` were built for specific briefs and kept in the repo as motion-grammar examples. They are not a catalogue to pick from.
+
 ## When to invoke
 
 - User shows a video, GIF, or storyboard and says "I want a Reels like this".

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -4,11 +4,15 @@ This file is for AI coding agents (Codex CLI, Cursor, etc.) working in this proj
 
 ## Quickstart
 
-When the user says "adforge", "start adforge", or asks for ads/creatives/campaigns:
+When the user asks for anything involving ads, creatives, variants, statics, motion, reels, hero images, or campaigns in this project — in any phrasing, not just the literal word "adforge":
 
-→ Read `.claude/skills/adforge/SKILL.md` and follow it.
+→ Read `.claude/skills/adforge/SKILL.md` FIRST and follow it.
 
-That is the hub. It routes to 4 mode skills depending on what the user wants:
+Examples that route through the hub: "make me a static", "draft an ad for X", "generate a reel", "I want something wild with a supernova", "new creative for the winter campaign", "turn this reference into an ad". Even a one-off "quick test image" goes through the hub — there is no shortcut path.
+
+**Never jump directly to `engines/static/compose.py`, `engines/motion/render.sh`, `generate_hero.py`, or a one-off Python/Node script to produce creatives.** The pipeline is deliberately skill-routed: hub → mode skill (`new-campaign` / `add-creative`) → `composer-speccer` → layout/motion synth when needed. Bypassing it produces template-reskinned output and re-bakes brand-specific work into ad-hoc scripts that no future user inherits.
+
+The hub is the router. It dispatches to 4 mode skills depending on what the user wants:
 
 - `.claude/skills/new-campaign/SKILL.md`
 - `.claude/skills/add-creative/SKILL.md`


### PR DESCRIPTION
## Summary

- Free-text ad requests ("make me a static", "generate a reel", "something wild with a supernova") were not routing through the `adforge` hub because the hub's skill `description` only matched literal "adforge" / "start adforge" phrasings. Result: agents jumped directly to `compose.py` / `render.sh` / one-off scripts and either reskinned existing compositions or wrote scratch PIL code — exactly the failure modes `composer-speccer` → `layout-synth` / `motion-synth` were designed to prevent.
- No shipped enforcement forbade bypassing the skill chain. The rule "if no layout fits, invoke layout-synth" only lived inside `composer-speccer`; an agent that skipped composer-speccer never read it.

## Changes

- `AGENTS.md`: broaden the entry rule with example phrasings and explicit anti-patterns (no direct `compose.py`, `render.sh`, `generate_hero.py`, or one-off scripts).
- `adforge/SKILL.md`: expand `description` frontmatter to match free-text intents.
- `composer-speccer/SKILL.md`: "Non-negotiable" preamble — never inline compose code; reuse is allowed only when the brief is structurally a match, not topically.
- `layout-synth/SKILL.md`: output always lands in `engines/static/examples/` so auto-discovery makes it inheritable; synth ≠ rename-and-tweak.
- `motion-synth/SKILL.md`: reuse of `ops-console` / `product-mockup` / `walkthrough` / `phone-notifications` with swapped copy is explicitly forbidden; "HaniCare-dispatcher look generalises" called out.

## Why

Two recent incidents surfaced the gap:
1. A Supernova static was produced via a `make_supernova.py` one-off instead of `layout-synth` → `engines/static/examples/fullbleed_hero.py`.
2. An Orbit E2E motion was produced by pointing a variant at `composition: "ops-console"` with Orbit copy swapped in → result looked like the reference brand's dispatcher UI.

Both failures happened because nothing in the skill chain blocked the shortcut.

## Test plan

- [ ] Read `AGENTS.md` top-to-bottom; entry rule should be unambiguous.
- [ ] `composer-speccer`, `layout-synth`, `motion-synth` preambles fire before any procedural steps.
- [ ] No behavioural code changes — docs-only PR; nothing to run.

Part 1 of 3 in v0.3.3. Follows up with PR B (compose/render error-path redirect) and PR C (de-bait example variants).