### PR TITLE
fix(engines): error path redirects to layout-synth / motion-synth

### DIFF
--- a/templates/engines/motion/render.sh
+++ b/templates/engines/motion/render.sh
@@ -29,6 +29,23 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$SCRIPT_DIR"
 
+# Pre-check the composition id is registered in Root.tsx. Remotion's own
+# error is terse; we want the agent/user to see the skill redirect path.
+if ! grep -qE "id=\"$COMPOSITION\"" src/Root.tsx; then
+  REGISTERED=$(grep -oE 'id="[^"]+"' src/Root.tsx | sed 's/id=//;s/"//g' | tr '\n' ' ')
+  cat >&2 <<EOF
+error: unknown composition '$COMPOSITION'.
+  registered in engines/motion/src/Root.tsx: $REGISTERED
+
+  To add a new composition, invoke the \`motion-synth\` skill — it synthesizes
+  a new <Name>.tsx under engines/motion/src/examples/ and registers it in
+  Root.tsx. Do NOT reuse an existing composition (ops-console, product-mockup,
+  walkthrough, phone-notifications) for a new brand by swapping variant copy —
+  that's reskinning, not a new ad.
+EOF
+  exit 2
+fi
+
 if [[ ! -d node_modules ]]; then
   echo "[render] installing deps (first run)..."
   npm install --silent

--- a/templates/engines/static/compose.py
+++ b/templates/engines/static/compose.py
@@ -42,7 +42,16 @@ def main():
     registry = discover()
     layout_name = variant.get("layout", "advertorial")
     if layout_name not in registry:
-        raise SystemExit(f"error: unknown layout '{layout_name}'. available: {sorted(registry)}")
+        raise SystemExit(
+            f"error: unknown layout '{layout_name}'.\n"
+            f"  available in engines/static/examples/: {sorted(registry)}\n"
+            f"\n"
+            f"  To add a new layout, invoke the `layout-synth` skill — it synthesizes\n"
+            f"  a new module under engines/static/examples/<name>.py (auto-discovered\n"
+            f"  on the next run). Do NOT edit compose.py, monkey-patch the registry,\n"
+            f"  or draft an inline PIL script — the new layout has to land as a module\n"
+            f"  so every user of this project inherits it."
+        )
 
     size = FORMATS[args.format]
     canvas, band_h = base_canvas(size, variant, brand)


### PR DESCRIPTION
## Summary

When `compose.py` or `render.sh` was called with a layout/composition that didn't exist, the error was terse (\"unknown layout 'X'. available: [...]\") and gave no guidance on *how* to add one. Result: agents would either edit `compose.py` inline, monkey-patch the registry, or drop an ad-hoc PIL script — bypassing the synth skills entirely.

## Changes

- `engines/static/compose.py`: on unknown layout, emit a multi-line error that names the synth skill (`layout-synth`), explains it produces an auto-discovered module, and explicitly forbids the bypass patterns.
- `engines/motion/render.sh`: pre-check the composition id against `src/Root.tsx` before invoking Remotion. On miss, emit a skill-redirect error pointing at `motion-synth`, and warn against reusing `ops-console` / `product-mockup` / `walkthrough` / `phone-notifications` with swapped copy.

## Why

Two recent incidents each produced a creative by bypassing the synth skills; the engine error surfaces were part of the gap because they signalled "no path forward via tools" instead of "use the synth skill." This PR turns the engine surface into a hint.

## Test plan

- [x] `python3 engines/static/compose.py variants/_bad.json 4x5 /tmp/x.png` with `\"layout\": \"does-not-exist\"` → exits 1 with the layout-synth redirect.
- [x] `engines/motion/render.sh /tmp/v.json not-a-real-composition /tmp/out.mp4` → exits 2 with the motion-synth redirect, lists registered compositions, never calls npx remotion.

Part 2 of 3 in v0.3.3 (follows #41). Precedes PR C (de-bait example variants).