### PR TITLE
fix(#34, #38): BFL preserves aspect ratio; generate_hero matches extension to actual format

### DIFF
--- a/templates/engines/static/generate_hero.py
+++ b/templates/engines/static/generate_hero.py
@@ -41,6 +41,16 @@ _IMAGE_SIGNATURES: list[tuple[bytes, str]] = [
     # WebP: "RIFF....WEBP" — prefix + offset 8 check handled separately.
 ]
 
+_VALID_EXTS_FOR_FORMAT: dict[str, set[str]] = {
+    "PNG":  {".png"},
+    "JPEG": {".jpg", ".jpeg"},
+    "GIF":  {".gif"},
+    "WebP": {".webp"},
+}
+_CANONICAL_EXT_FOR_FORMAT: dict[str, str] = {
+    "PNG": ".png", "JPEG": ".jpg", "GIF": ".gif", "WebP": ".webp",
+}
+
 
 def _detect_format(data: bytes) -> str | None:
     for sig, name in _IMAGE_SIGNATURES:
@@ -196,9 +206,26 @@ def main() -> int:
         _eprint(f"[generate_hero] unexpected {type(e).__name__} from {name!r} — see CONTRACT.md")
         return 1
 
+    # Ensure the output path's extension matches the actual image format.
+    # Providers may legitimately return JPEG when the caller asked for PNG;
+    # writing JPEG bytes to a .png path leaves downstream tools (Meta upload,
+    # PIL Image.open, file(1)) to cope with a lying extension.
+    fmt = _detect_format(image_bytes)
+    if fmt and output_path.suffix.lower() not in _VALID_EXTS_FOR_FORMAT.get(fmt, set()):
+        new_path = output_path.with_suffix(_CANONICAL_EXT_FOR_FORMAT[fmt])
+        _eprint(
+            f"[generate_hero] provider returned {fmt} but output path was "
+            f"{output_path.name} — writing to {new_path.name} instead"
+        )
+        output_path = new_path
+
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_bytes(image_bytes)
     _eprint(f"[generate_hero] saved {output_path} ({len(image_bytes)} bytes)")
+    # Print the final path on stdout so callers can capture it — extension
+    # may differ from what they requested if the provider returned a
+    # different format.
+    print(output_path)
     return 0
 
 

--- a/templates/engines/static/image_providers/bfl.py
+++ b/templates/engines/static/image_providers/bfl.py
@@ -34,6 +34,11 @@ _DIM_MAX = 1440
 _DIM_STEP = 32
 
 
+def _eprint(msg: str) -> None:
+    import sys
+    print(msg, file=sys.stderr)
+
+
 def _api_key() -> str:
     key = os.environ.get("BFL_API_KEY", "").strip()
     if not key:
@@ -52,10 +57,37 @@ def _error_detail(body: str, limit: int = 300) -> str:
     return s[:limit] + ("…" if len(s) > limit else "")
 
 
-def _snap(value: int) -> int:
-    """Clamp to [_DIM_MIN, _DIM_MAX] and round to nearest multiple of _DIM_STEP."""
-    v = max(_DIM_MIN, min(_DIM_MAX, int(value)))
-    return max(_DIM_MIN, min(_DIM_MAX, round(v / _DIM_STEP) * _DIM_STEP))
+def _snap_dims(width: int, height: int) -> tuple[int, int]:
+    """Clamp (w, h) into BFL's valid range [_DIM_MIN, _DIM_MAX] preserving the
+    requested aspect ratio, then round each dim to the nearest _DIM_STEP
+    multiple. Clamping each dim independently (the previous behavior) silently
+    destroyed aspect — e.g. 1728×2160 (4:5) became 1440×1440 (1:1) because
+    both dims hit the cap. Now we scale proportionally first so a 4:5 request
+    comes back ~4:5."""
+    w_req = max(1, int(width))
+    h_req = max(1, int(height))
+
+    # 1) scale down proportionally if either dim exceeds the cap
+    scale = min(1.0, _DIM_MAX / w_req, _DIM_MAX / h_req)
+    # 2) scale up proportionally if either dim is below the floor
+    scale = max(scale, _DIM_MIN / w_req, _DIM_MIN / h_req)
+
+    w = w_req * scale
+    h = h_req * scale
+
+    # 3) round to 32-multiple and re-clamp (rounding can push past the edge)
+    def _round_clamp(v: float) -> int:
+        v = round(v / _DIM_STEP) * _DIM_STEP
+        return int(max(_DIM_MIN, min(_DIM_MAX, v)))
+
+    w_out, h_out = _round_clamp(w), _round_clamp(h)
+
+    if (w_out, h_out) != (w_req, h_req):
+        _eprint(
+            f"[bfl] snapped requested {w_req}x{h_req} -> {w_out}x{h_out} "
+            f"(BFL accepts {_DIM_MIN}–{_DIM_MAX}, multiples of {_DIM_STEP})"
+        )
+    return w_out, h_out
 
 
 def _post_json(url: str, body: dict, headers: dict) -> dict:
@@ -102,7 +134,8 @@ def _download(url: str) -> bytes:
 def generate(prompt: str, width: int, height: int) -> bytes:
     model = _model()
     headers = {"x-key": _api_key()}
-    body = {"prompt": prompt, "width": _snap(width), "height": _snap(height)}
+    w, h = _snap_dims(width, height)
+    body = {"prompt": prompt, "width": w, "height": h}
 
     submit = _post_json(f"{ENDPOINT}/{model}", body, headers)
     job_id = submit.get("id")

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -856,6 +856,97 @@ else
   cat "$WORK/dispatcher-bfl-model.log"
 fi
 
+# 2f.7b — _snap_dims preserves aspect ratio when clamping (#34). The previous
+# _snap() clamped each dim independently, so 1728x2160 (4:5) came back as
+# 1440x1440 (1:1). _snap_dims scales proportionally first.
+if env -i PATH="$PATH" python3 - <<PY > "$WORK/bfl-aspect.log" 2>&1
+import importlib.util
+from pathlib import Path
+spec = importlib.util.spec_from_file_location(
+    "bfl_aspect",
+    Path("$PROJECT/engines/static/image_providers/bfl.py"),
+)
+bfl = importlib.util.module_from_spec(spec); spec.loader.exec_module(bfl)
+
+# 4:5 portrait above the cap -> scales down proportionally to hit 1440 on the
+# taller side, shorter side scales to match the requested aspect ratio.
+w, h = bfl._snap_dims(1728, 2160)
+assert h == 1440, (w, h)  # the dim that hit the cap
+assert w % 32 == 0 and h % 32 == 0, (w, h)
+# aspect should be within one 32-step of requested 4:5 = 0.8
+ratio = w / h
+assert abs(ratio - 0.8) < 0.03, (w, h, ratio)
+
+# 16:9 wider than cap -> still preserves aspect
+w, h = bfl._snap_dims(1920, 1080)
+assert w == 1440, (w, h)
+assert abs((w / h) - (16 / 9)) < 0.05, (w, h)
+
+# already-valid dims pass through unchanged
+w, h = bfl._snap_dims(1024, 1024)
+assert (w, h) == (1024, 1024), (w, h)
+
+# dims below floor scale up proportionally
+w, h = bfl._snap_dims(100, 200)  # aspect 1:2
+assert w >= 256 and h >= 256
+assert abs((w / h) - 0.5) < 0.08, (w, h)
+print("ok")
+PY
+then
+  pass "bfl _snap_dims preserves aspect ratio when clamping"
+else
+  fail "bfl aspect-ratio snap"
+  cat "$WORK/bfl-aspect.log"
+fi
+
+# 2f.7c — generate_hero writes to the correct extension when the provider
+# returns a different format than the output path implies (#38).
+if env -i PATH="$PATH" python3 - <<PY > "$WORK/generate-hero-ext.log" 2>&1
+import importlib.util, sys, tempfile, os, io
+from pathlib import Path
+spec = importlib.util.spec_from_file_location(
+    "gh",
+    Path("$PROJECT/engines/static/generate_hero.py"),
+)
+gh = importlib.util.module_from_spec(spec); spec.loader.exec_module(gh)
+
+# Force the internal generate to return JPEG bytes
+gh.generate_hero = lambda prompt, w, h, provider=None: b"\xff\xd8\xff\xe0JPEG-ish"
+gh.pick_provider = lambda: "bfl"
+
+with tempfile.TemporaryDirectory() as td:
+    requested = Path(td) / "orbit_hero_4x5.png"
+    sys.argv = ["generate_hero.py", str(requested), "1024", "1024"]
+    sys.stdin = io.StringIO("prompt")
+
+    # capture stdout (the final path)
+    buf = io.StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = buf
+    try:
+        rc = gh.main()
+    finally:
+        sys.stdout = old_stdout
+    assert rc == 0, rc
+
+    # requested .png should not exist
+    assert not requested.exists(), requested
+    # .jpg should exist
+    final = requested.with_suffix(".jpg")
+    assert final.exists(), final
+    assert final.read_bytes().startswith(b"\xff\xd8\xff"), "not JPEG"
+
+    # stdout reports the final path
+    assert buf.getvalue().strip().endswith("orbit_hero_4x5.jpg"), buf.getvalue()
+print("ok")
+PY
+then
+  pass "generate_hero rewrites extension to match returned format"
+else
+  fail "generate_hero extension rewrite"
+  cat "$WORK/generate-hero-ext.log"
+fi
+
 # 2f.8 — flux.sh is still callable (backcompat wrapper). Feeds stdin prompt
 # and a non-existent output path through a dry wrapper: we don't want a real
 # BFL call, so we intercept by replacing generate_hero.py's generate call via


### PR DESCRIPTION
## Summary
- **#34** — BFL dimension clamp now preserves aspect ratio. Old `_snap` squeezed each axis independently, so 1728×2160 (4:5) came back 1440×1440 (1:1). New `_snap_dims` scales proportionally first, then rounds to BFL's 32-step grid.
- **#38** — `generate_hero.py` now rewrites the output path extension to match the actual returned format. Providers may legitimately return JPEG when the caller's path ends in `.png`; the dispatcher detects from magic bytes and writes to `.jpg` instead, logging the rewrite and printing the final path on stdout for callers to capture.

## Test plan
- [x] `bash test/run-tests.sh` — 51 passed (up from 49; two new tests 2f.7b + 2f.7c)
- [x] Manual: `_snap_dims(1024, 1024) == (1024, 1024)` (unchanged)
- [x] Manual: `_snap_dims(1728, 2160)` → 1152×1440 (4:5 preserved, stderr log)

Closes #34, closes #38.