### PR TITLE
fix: replace deprecated datetime.utcnow() in review.py

### DIFF
--- a/templates/adapters/meta/review.py
+++ b/templates/adapters/meta/review.py
@@ -111,7 +111,7 @@ def main():
 
     reports_dir = project_root / ".adforge" / "reports"
     reports_dir.mkdir(parents=True, exist_ok=True)
-    ts = dt.datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    ts = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     out = reports_dir / f"review-{args.level}-{args.days}d-{ts}.json"
     out.write_text(json.dumps({"generated_at": ts, "level": args.level, "days": args.days, "rows": rows}, indent=2))
     print(f"\nreport: {out.relative_to(project_root)}")


### PR DESCRIPTION
## Summary

- Replace `dt.datetime.utcnow()` with tz-aware `dt.datetime.now(dt.timezone.utc)` in `adapters/meta/review.py:114` — closes #40.
- Output format (`%Y%m%dT%H%M%SZ`) unchanged; no behavioral difference, just removes the Python 3.12+ `DeprecationWarning`.

## Test plan

- [ ] `python3 adapters/meta/review.py` produces the same `review-<level>-<N>d-<ts>.json` filename shape
- [ ] No `DeprecationWarning` in stderr on Python 3.12+